### PR TITLE
allow for `~` and `@` in the name component of a Onestop ID

### DIFF
--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -85,7 +85,7 @@ class OnestopId
     end
 
     if !valid_component?(:name, onestop_id.split(COMPONENT_SEPARATOR)[2])
-      errors << 'must include only letters and digits in its abbreviated name (the 3rd component)'
+      errors << 'must include only letters, digits, and ~ or @ in its abbreviated name (the 3rd component)'
       is_a_valid_onestop_id = false
     end
     return is_a_valid_onestop_id, errors
@@ -101,7 +101,7 @@ class OnestopId
     when :geohash
       !(value =~ /[^a-z\d]/)
     when :name
-      !(value =~ /[^a-zA-Z\d]/)
+      !(value =~ /[^a-zA-Z\d\@\~]/)
     else
       false
     end

--- a/spec/models/concerns/has_a_onestop_id_spec.rb
+++ b/spec/models/concerns/has_a_onestop_id_spec.rb
@@ -22,7 +22,7 @@ describe HasAOnestopId do
     it 'must include only letters and digits in its abbreviated name (the 3rd component)' do
       stop = Stop.new(onestop_id: '6s-9y7pwu-RetSt#a', geometry: 'POINT(-58.374722 -34.591389)')
       expect(stop.valid?).to be false
-      expect(stop.errors.messages[:onestop_id]).to include 'must include only letters and digits in its abbreviated name (the 3rd component)'
+      expect(stop.errors.messages[:onestop_id]).to include 'must include only letters, digits, and ~ or @ in its abbreviated name (the 3rd component)'
     end
   end
 end

--- a/spec/services/onestop_id_spec.rb
+++ b/spec/services/onestop_id_spec.rb
@@ -33,10 +33,14 @@ describe OnestopId do
       expect(errors).to include 'must include a valid geohash as its 2nd component'
     end
 
-    it 'must include only letters and digits in its abbreviated name (the 3rd component)' do
-      is_a_valid_onestop_id, errors = OnestopId.validate_onestop_id_string('6s-9y7pwu-RetSt#a')
+    it 'must include only letters, digits, and ~ or @ in its abbreviated name (the 3rd component)' do
+      is_a_valid_onestop_id, errors = OnestopId.validate_onestop_id_string('s-9y7pwu-RetSt#a')
       expect(is_a_valid_onestop_id).to be false
-      expect(errors).to include 'must include only letters and digits in its abbreviated name (the 3rd component)'
+      expect(errors).to include 'must include only letters, digits, and ~ or @ in its abbreviated name (the 3rd component)'
+      is_a_valid_onestop_id, errors = OnestopId.validate_onestop_id_string('s-9y7pwu-RetSt~a')
+      expect(is_a_valid_onestop_id).to be true
+      is_a_valid_onestop_id, errors = OnestopId.validate_onestop_id_string('s-9y7pwu-RetSt@a')
+      expect(is_a_valid_onestop_id).to be true
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/lNTgVIRI