### PR TITLE
add Sentry for Rails exception tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'airborne', group: :test
 
 # deployment and monitoring
 gem 'aws-sdk', group: [:staging, :production]
+gem 'sentry-raven', group: [:staging, :production]
 gem 'bullet', group: :development
 
 # web server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,8 @@ GEM
     ruby-graphviz (1.0.9)
     rubyzip (1.1.7)
     safe_yaml (1.0.4)
+    sentry-raven (0.13.3)
+      faraday (>= 0.7.6)
     sidekiq (3.3.4)
       celluloid (>= 0.16.0)
       connection_pool (>= 2.1.1)
@@ -352,6 +354,7 @@ DEPENDENCIES
   redis-rails
   rgeo-geojson
   rspec-rails
+  sentry-raven
   sidekiq
   simplecov
   sinatra


### PR DESCRIPTION
SENTRY_DSN can be set as an env variable