### PR TITLE
Handle references to non-existent parent_station

### DIFF
--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -118,6 +118,7 @@ class Operator < BaseOperator
   include FromGTFS
   def self.from_gtfs(entity, stops)
     # GTFS Constructor
+    raise ArgumentError.new('Need at least one Stop') if stops.empty?
     geohash = GeohashHelpers.fit(stops.map { |i| i[:geometry] })
     geometry = Operator.convex_hull(stops, as: :wkt, projected: false)
     name = [entity.name, entity.id, "unknown"]

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -130,6 +130,7 @@ class Route < BaseRoute
   include FromGTFS
   def self.from_gtfs(entity, stops)
     # GTFS Constructor
+    raise ArgumentError.new('Need at least one Stop') if stops.empty?
     geohash = GeohashHelpers.fit(stops.map { |i| i[:geometry] })
     name = [entity.short_name, entity.long_name, entity.id, "unknown"]
       .select(&:present?)

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -106,7 +106,7 @@ class GTFSGraph
     # Merge child stations into parents.
     stations = Hash.new { |h,k| h[k] = [] }
     @gtfs_by_id[:stops].each do |k,e|
-      stations[@gtfs_by_id[:stops][e.parent_station || e.id]] << e
+      stations[@gtfs_by_id[:stops][e.parent_station] || e] << e
     end
     
     # Merge station/platforms with Datastore Stops.


### PR DESCRIPTION
At least one stop is necessary to calculate a geohash for Operators and
Stops.