### PR TITLE
FeedEater performance and bug fixes

### DIFF
--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -65,7 +65,7 @@ class ScheduleStopPair < BaseScheduleStopPair
   belongs_to :route
 
   # Required relations and attributes
-  validates :route, presence: true
+  validates :origin, presence: true
   validates :destination, presence: true
   validates :route, presence: true
   validates :trip, presence: true

--- a/config/initializers/gtfs.rb
+++ b/config/initializers/gtfs.rb
@@ -1,0 +1,11 @@
+# Patch gtfs to skip costly renaming in stop_times.txt
+# ~3x performance improvement
+require 'gtfs'
+
+module GTFS
+  class StopTime
+    def self.parse_model(attr_hash, options={})
+      self.new(attr_hash)
+    end
+  end
+end

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -463,8 +463,8 @@ class GTFSGraph
       serviceStartDate: nil,
       serviceEndDate: nil,
       serviceDaysOfWeek: [false] * 7,
-      serviceAdded: [],
-      serviceExcept: []
+      serviceAddedDates: [],
+      serviceExceptDates: []
     }
     # check if we're calendar.txt, ...
     service[:serviceStartDate] ||= entity.try(:start_date).try(:to_date)
@@ -475,9 +475,9 @@ class GTFSGraph
     # or calendar_dates.txt
     if entity.respond_to?(:date)
       if entity.exception_type.to_i == 1
-        service[:serviceAdded] << entity.date.to_date
+        service[:serviceAddedDates] << entity.date.to_date
       else
-        service[:serviceExcept] << entity.date.to_date
+        service[:serviceExceptDates] << entity.date.to_date
       end      
     end
     @service_by_id[entity.service_id] = service

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -52,8 +52,8 @@ class GTFSGraph
 
     # Load service periods
     debug "  calendars"
-    @gtfs.each_calendar { |e| make_service(e) }    
-    @gtfs.each_calendar_date { |e| make_service(e) }
+    @gtfs.each_calendar { |e| make_service(e) } rescue debug "  warning: no calendar.txt"
+    @gtfs.each_calendar_date { |e| make_service(e) } rescue debug "  warning: no calendar_dates.txt"
 
     # Load shapes.
     debug "  shapes"
@@ -207,6 +207,7 @@ class GTFSGraph
   end
   
   def create_changeset(operators, import_level=0)
+    raise ArgumentError.new('At least one operator required') if operators.empty?
     raise ArgumentError.new('import_level must be 0, 1, or 2.') unless (0..2).include?(import_level)
     debug "Create Changeset"
     operators = operators

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -1,9 +1,9 @@
 class GTFSGraph
   
   DAYS_OF_WEEK = [:monday, :tuesday, :wednesday, :thursday, :friday, :saturday, :sunday]
-  CHUNKSIZE = 1_000
-  STOPTIMESSIZE = 1_000_000
-  
+  CHANGE_PAYLOAD_MAX_ENTITIES = 1_000
+  STOP_TIMES_MAX_LOAD = 1_000_000
+    
   def initialize(filename, feed=nil)
     # GTFS Graph / TransitLand wrapper
     @filename = filename
@@ -218,7 +218,7 @@ class GTFSGraph
     
     # Operators
     if import_level >= 0
-      operators.each_slice(CHUNKSIZE).each do |chunk|
+      operators.each_slice(CHANGE_PAYLOAD_MAX_ENTITIES).each do |chunk|
         debug "  operators: #{chunk.size}"
         ChangePayload.create!(
           changeset: changeset, 
@@ -236,7 +236,7 @@ class GTFSGraph
 
     # Stops
     if import_level >= 1
-      stops.each_slice(CHUNKSIZE).each do |chunk|
+      stops.each_slice(CHANGE_PAYLOAD_MAX_ENTITIES).each do |chunk|
         debug "  stops: #{chunk.size}"
         ChangePayload.create!(
           changeset: changeset, 
@@ -252,7 +252,7 @@ class GTFSGraph
       end
     
       # Routes
-      routes.each_slice(CHUNKSIZE).each do |chunk|
+      routes.each_slice(CHANGE_PAYLOAD_MAX_ENTITIES).each do |chunk|
         debug "  routes: #{chunk.size}"
         ChangePayload.create!(
           changeset: changeset, 
@@ -270,9 +270,9 @@ class GTFSGraph
 
     if import_level >= 2
       counter = 0
-      trip_chunks(STOPTIMESSIZE) do |trip_chunk|
+      trip_chunks(STOP_TIMES_MAX_LOAD) do |trip_chunk|
         counter += trip_chunk.size
-        stop_pairs(trip_chunk).each_slice(CHUNKSIZE) do |chunk|
+        stop_pairs(trip_chunk).each_slice(CHANGE_PAYLOAD_MAX_ENTITIES) do |chunk|
           debug "  trips #{counter} / #{@trip_counter.size}: #{chunk.size} stop pairs"
           ChangePayload.create!(
             changeset: changeset,
@@ -335,7 +335,7 @@ class GTFSGraph
   
   ##### Trip pairs and stop chunks #####
   
-  def trip_chunks(batchsize=1000)
+  def trip_chunks(batchsize)
     # Return chunks of trips containing approx. batchsize stop_times.
     # Reverse sort trips
     trips = @trip_counter.sort_by { |k,v| -v }

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -362,7 +362,7 @@ class GTFSGraph
 
     # Sub graph mapping trip IDs to stop_times
     trip_ids_stop_times = Hash.new {|h,k| h[k] = []}
-    @gtfs.stop_times.each do |stop_time|
+    @gtfs.each_stop_time do |stop_time|
       next unless trip_ids.include?(stop_time.trip_id)
       trip_ids_stop_times[stop_time.trip_id] << stop_time
     end 


### PR DESCRIPTION
Use feed.each_entity instead of feed.entities.each.

Monkey patch GTFS to skip key renaming on stop_times.txt, for a 3x speed improvement.

Ignore missing calendar.txt & calendar_dates.txt flles.

Bug fixes: validate origin stop presence, service_added_dates