### PR TITLE
GTFS wrapper fix for PANYNJ PATH

### DIFF
--- a/app/workers/feed_eater_feed_worker.rb
+++ b/app/workers/feed_eater_feed_worker.rb
@@ -55,7 +55,6 @@ class FeedEaterFeedWorker < FeedEaterWorker
       end
     ensure
       # Save logs and reports
-      # binding.pry
       logger.info "FeedEaterFeedWorker #{feed_onestop_id}: Saving log & report"
       feed_import.update(import_log: graph.try(:import_log))
     end

--- a/config/initializers/gtfs.rb
+++ b/config/initializers/gtfs.rb
@@ -8,4 +8,15 @@ module GTFS
       self.new(attr_hash)
     end
   end
+
+  module Model
+    module ClassMethods
+      def each(filename)
+        CSV.foreach(filename, :headers => true, :encoding => 'bom|utf-8') do |row|
+          yield parse_model(row.to_hash)
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
gtfs wrapper has two code paths for reading csv; one did not pass in
'bom|utf-8' as the file encoding.