### PR TITLE
Schedule stop pair interpolation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', ref: '6bf1bc8d48308d3c3496089245d0bf38fbf1deb5'
+gem 'gtfs', github: 'transitland/gtfs', tag: 'v1.0.0rc4'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', tag: 'v1.0.0rc3'
+gem 'gtfs', github: 'transitland/gtfs', ref: 'b64e9fb76e0fc1f95fe234410430f6e4b5f06f8e'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', tag: 'v1.0.0rc1'
+gem 'gtfs', github: 'transitland/gtfs', tag: 'v1.0.0rc2'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', ref: 'b64e9fb76e0fc1f95fe234410430f6e4b5f06f8e'
+gem 'gtfs', github: 'transitland/gtfs', ref: '6bf1bc8d48308d3c3496089245d0bf38fbf1deb5'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', tag: 'v1.0.0rc2'
+gem 'gtfs', github: 'transitland/gtfs', tag: 'v1.0.0rc3'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: 21453060861b955ca63a06aec12fba34f677dfa3
-  tag: v1.0.0rc1
+  revision: 7ebe6ce14b9432bd201e00397fd7bcab1eb3f417
+  tag: v1.0.0rc2
   specs:
-    gtfs (0.2.5)
+    gtfs (1.0.0rc2)
       multi_json
       rake
       rubyzip (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: 5d42132041168eae862f3610dac524d448c9ae3e
-  tag: v1.0.0rc3
+  revision: b64e9fb76e0fc1f95fe234410430f6e4b5f06f8e
+  ref: b64e9fb76e0fc1f95fe234410430f6e4b5f06f8e
   specs:
     gtfs (1.0.0rc3)
       multi_json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: 7ebe6ce14b9432bd201e00397fd7bcab1eb3f417
-  tag: v1.0.0rc2
+  revision: 5d42132041168eae862f3610dac524d448c9ae3e
+  tag: v1.0.0rc3
   specs:
-    gtfs (1.0.0rc2)
+    gtfs (1.0.0rc3)
       multi_json
       rake
       rubyzip (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: b64e9fb76e0fc1f95fe234410430f6e4b5f06f8e
-  ref: b64e9fb76e0fc1f95fe234410430f6e4b5f06f8e
+  revision: 6bf1bc8d48308d3c3496089245d0bf38fbf1deb5
+  ref: 6bf1bc8d48308d3c3496089245d0bf38fbf1deb5
   specs:
     gtfs (1.0.0rc3)
       multi_json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: 6bf1bc8d48308d3c3496089245d0bf38fbf1deb5
-  ref: 6bf1bc8d48308d3c3496089245d0bf38fbf1deb5
+  revision: 0c3b2c2706bafeb4df83ca955dbee184d4f6a8b7
+  tag: v1.0.0rc4
   specs:
-    gtfs (1.0.0rc3)
+    gtfs (1.0.0rc4)
       multi_json
       rake
       rubyzip (~> 1.1)

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -63,7 +63,7 @@ class ScheduleStopPair < BaseScheduleStopPair
   belongs_to :route
 
   # Required relations and attributes
-  before_validation :set_service_range
+  before_validation :filter_service_range
   validates :origin,
             :destination,
             :route,
@@ -209,10 +209,16 @@ class ScheduleStopPair < BaseScheduleStopPair
   end
 
   # Set a service range from service_added_dates, service_except_dates
-  def set_service_range
+  def expand_service_range
     self.service_start_date ||= (service_except_dates + service_added_dates).min
     self.service_end_date ||= (service_except_dates + service_added_dates).max
     true
+  end
+
+  def filter_service_range
+    expand_service_range
+    self.service_added_dates = service_added_dates.select { |x| x.between?(service_start_date, service_end_date)}.sort
+    self.service_except_dates = service_except_dates.select { |x| x.between?(service_start_date, service_end_date)}.sort
   end
 
   # Make sure service_start_date < service_end_date

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -185,7 +185,7 @@ class ScheduleStopPair < BaseScheduleStopPair
     ssps.each do |ssp|
       group << ssp
       if ssp.destination_arrival_time
-        groups << group # if group.size > 1
+        groups << group
         group = []
       end
     end

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -131,6 +131,22 @@ class ScheduleStopPair < BaseScheduleStopPair
     super(dates.map { |x| x.is_a?(Date) ? x : Date.parse(x) }.uniq)
   end
 
+  def origin_arrival_time=(value)
+    super(GTFS::WideTime.parse(value))
+  end
+
+  def origin_departure_time=(value)
+    super(GTFS::WideTime.parse(value))
+  end
+
+  def destination_arrival_time=(value)
+    super(GTFS::WideTime.parse(value))
+  end
+
+  def destination_departure_time=(value)
+    super(GTFS::WideTime.parse(value))
+  end
+
   # Tracked by changeset
   include CurrentTrackedByChangeset
   current_tracked_by_changeset({

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -31,10 +31,13 @@
 #  bikes_allowed                      :integer
 #  pickup_type                        :integer
 #  drop_off_type                      :integer
-#  timepoint                          :integer
 #  shape_dist_traveled                :float
 #  origin_timezone                    :string
 #  destination_timezone               :string
+#  window_start                       :string
+#  window_end                         :string
+#  origin_timepoint_source            :string
+#  destination_timepoint_source       :string
 #
 # Indexes
 #

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -63,13 +63,20 @@ class ScheduleStopPair < BaseScheduleStopPair
   belongs_to :route
 
   # Required relations and attributes
-  validates :origin, presence: true
-  validates :destination, presence: true
-  validates :route, presence: true
-  validates :trip, presence: true
-
-  # Check date ranges
   before_validation :set_service_range
+  validates :origin,
+            :destination,
+            :route,
+            :trip,
+            :origin_timezone,
+            :destination_timezone,
+            :origin_arrival_time,
+            :origin_departure_time,
+            :destination_arrival_time,
+            :destination_departure_time,
+            :service_start_date,
+            :service_end_date,
+            presence: true
   validate :validate_service_range
   validate :validate_service_exceptions
 
@@ -178,11 +185,9 @@ class ScheduleStopPair < BaseScheduleStopPair
     self.service_end_date ||= (service_except_dates + service_added_dates).max
     true
   end
-  
+
   # Make sure service_start_date < service_end_date
   def validate_service_range
-    errors.add(:service_start_date, "service_start_date required") unless service_start_date
-    errors.add(:service_end_date, "service_end_date required") unless service_end_date
     if service_start_date && service_end_date
       errors.add(:service_start_date, "service_start_date begins after service_end_date") if service_start_date > service_end_date
     end
@@ -197,7 +202,6 @@ class ScheduleStopPair < BaseScheduleStopPair
       errors.add(:service_except_dates, "service_except_dates must be within service_start_date, service_end_date range")
     end
   end
-
 end
 
 class OldScheduleStopPair < BaseScheduleStopPair

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -55,6 +55,22 @@ class BaseScheduleStopPair < ActiveRecord::Base
   self.abstract_class = true
   PER_PAGE = 50
   include IsAnEntityImportedFromFeeds
+
+  extend Enumerize
+  enumerize :origin_timepoint_source, in: [
+      :gtfs_exact,
+      :gtfs_interpolated,
+      :transitland_interpolated_linear,
+      :transitland_interpolated_geometric,
+      :transitland_interpolated_shape
+    ]
+  enumerize :destination_timepoint_source, in: [
+      :gtfs_exact,
+      :gtfs_interpolated,
+      :transitland_interpolated_linear,
+      :transitland_interpolated_geometric,
+      :transitland_interpolated_shape
+    ]
 end
 
 class ScheduleStopPair < BaseScheduleStopPair

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -169,6 +169,15 @@ class ScheduleStopPair < BaseScheduleStopPair
     duration = window_end - window_start
     step = duration / group.size.to_f
     current = window_start
+    # puts "  ============================"
+    # puts "  group: #{group.size}"
+    # puts "  window_start: #{window_start}"
+    # puts "  window_end: #{window_end}"
+    # puts "  duration: #{duration}"
+    # puts "  step: #{step}"
+    # group.each do |g|
+    #   puts "    oa: #{g.origin_arrival_time} od: #{g.origin_departure_time} --> da: #{g.destination_arrival_time} dd: #{g.destination_departure_time}"
+    # end
     group[0..-2].zip(group[1..-1]) do |a,b|
       current += step
       t = GTFS::WideTime.new(current.to_i).to_s
@@ -177,6 +186,10 @@ class ScheduleStopPair < BaseScheduleStopPair
       b.origin_arrival_time = t
       b.origin_departure_time = t
     end
+    # puts "  ~~ interpolated ~~"
+    # group.each do |g|
+    #   puts "    oa: #{g.origin_arrival_time} od: #{g.origin_departure_time} --> da: #{g.destination_arrival_time} dd: #{g.destination_departure_time}"
+    # end
   end
 
   # Set a service range from service_added_dates, service_except_dates

--- a/app/serializers/schedule_stop_pair_serializer.rb
+++ b/app/serializers/schedule_stop_pair_serializer.rb
@@ -31,10 +31,13 @@
 #  bikes_allowed                      :integer
 #  pickup_type                        :integer
 #  drop_off_type                      :integer
-#  timepoint                          :integer
 #  shape_dist_traveled                :float
 #  origin_timezone                    :string
 #  destination_timezone               :string
+#  window_start                       :string
+#  window_end                         :string
+#  origin_timepoint_source            :string
+#  destination_timepoint_source       :string
 #
 # Indexes
 #

--- a/app/serializers/schedule_stop_pair_serializer.rb
+++ b/app/serializers/schedule_stop_pair_serializer.rb
@@ -65,7 +65,6 @@ class ScheduleStopPairSerializer < ApplicationSerializer
              :bikes_allowed,
              :pickup_type,
              :drop_off_type,
-             :timepoint,
              :shape_dist_traveled,
              :origin_arrival_time,
              :origin_departure_time,
@@ -76,17 +75,21 @@ class ScheduleStopPairSerializer < ApplicationSerializer
              :service_added_dates,
              :service_except_dates,
              :service_days_of_week,
+             :window_start,
+             :window_end,
+             :origin_timepoint_source,
+             :destination_timepoint_source,
              :created_at,
              :updated_at
 
   def origin_onestop_id
     object.origin.try(:onestop_id)
   end
-  
+
   def destination_onestop_id
     object.destination.try(:onestop_id)
   end
-  
+
   def route_onestop_id
     object.route.try(:onestop_id)
   end

--- a/db/migrate/20150930002948_add_window_and_timepoints_to_schedule_stop_pair.rb
+++ b/db/migrate/20150930002948_add_window_and_timepoints_to_schedule_stop_pair.rb
@@ -1,0 +1,11 @@
+class AddWindowAndTimepointsToScheduleStopPair < ActiveRecord::Migration
+  def change
+    [:current, :old].each do |version|
+      remove_column "#{version}_schedule_stop_pairs", :timepoint
+      add_column "#{version}_schedule_stop_pairs", :window_start, :string
+      add_column "#{version}_schedule_stop_pairs", :window_end, :string
+      add_column "#{version}_schedule_stop_pairs", :origin_timepoint_source, :string
+      add_column "#{version}_schedule_stop_pairs", :destination_timepoint_source, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150923173046) do
+ActiveRecord::Schema.define(version: 20150930002948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -172,10 +172,13 @@ ActiveRecord::Schema.define(version: 20150923173046) do
     t.integer  "bikes_allowed"
     t.integer  "pickup_type"
     t.integer  "drop_off_type"
-    t.integer  "timepoint"
     t.float    "shape_dist_traveled"
     t.string   "origin_timezone"
     t.string   "destination_timezone"
+    t.string   "window_start"
+    t.string   "window_end"
+    t.string   "origin_timepoint_source"
+    t.string   "destination_timepoint_source"
   end
 
   add_index "current_schedule_stop_pairs", ["created_or_updated_in_changeset_id"], name: "c_ssp_cu_in_changeset", using: :btree
@@ -398,10 +401,13 @@ ActiveRecord::Schema.define(version: 20150923173046) do
     t.integer  "bikes_allowed"
     t.integer  "pickup_type"
     t.integer  "drop_off_type"
-    t.integer  "timepoint"
     t.float    "shape_dist_traveled"
     t.string   "origin_timezone"
     t.string   "destination_timezone"
+    t.string   "window_start"
+    t.string   "window_end"
+    t.string   "origin_timepoint_source"
+    t.string   "destination_timepoint_source"
   end
 
   add_index "old_schedule_stop_pairs", ["created_or_updated_in_changeset_id"], name: "o_ssp_cu_in_changeset", using: :btree

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -1,7 +1,7 @@
 class GTFSGraph
 
   CHANGE_PAYLOAD_MAX_ENTITIES = 1_000
-  STOP_TIMES_MAX_LOAD = 1_000_000
+  STOP_TIMES_MAX_LOAD = 100_000
 
   def initialize(filename, feed=nil)
     # GTFS Graph / TransitLand wrapper
@@ -237,8 +237,8 @@ class GTFSGraph
         end
         # Create changeset
         ssp_chunk.each_slice(CHANGE_PAYLOAD_MAX_ENTITIES) do |chunk|
-          log "    ssp changes: #{ssp_counter} - #{ssp_counter+ssp_chunk.size}"
-          ssp_counter += ssp_chunk.size
+          log "    ssp changes: #{ssp_counter} - #{ssp_counter+chunk.size}"
+          ssp_counter += chunk.size
           ChangePayload.create!(
             changeset: changeset,
             payload: {
@@ -392,7 +392,6 @@ class GTFSGraph
       # Stop Time
       drop_off_type: origin.drop_off_type.to_i,
       pickup_type: origin.pickup_type.to_i,
-      # timepoint: origin.timepoint.to_i,
       shape_dist_traveled: origin.shape_dist_traveled.to_f,
       # service period
       service_start_date: service_period.start_date,

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -387,6 +387,7 @@ class GTFSGraph
       trip_headsign: (origin.stop_headsign || trip.trip_headsign),
       trip_short_name: trip.trip_short_name,
       wheelchair_accessible: trip.wheelchair_accessible.to_i,
+      bikes_allowed: trip.bikes_allowed.to_i,
       # Stop Time
       drop_off_type: origin.drop_off_type.to_i,
       pickup_type: origin.pickup_type.to_i,

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -360,7 +360,11 @@ class GTFSGraph
       serviceEndDate: entity.service_end_date,
       serviceDaysOfWeek: entity.service_days_of_week,
       serviceAddedDates: entity.service_added_dates,
-      serviceExceptDates: entity.service_except_dates
+      serviceExceptDates: entity.service_except_dates,
+      windowStart: entity.window_start,
+      windowEnd: entity.window_end,
+      originTimepointSource: entity.origin_timepoint_source,
+      destinationTimepointSource: entity.destination_timepoint_source
     }
   end
 

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -373,19 +373,19 @@ class GTFSGraph
       # Origin
       origin: origin_stop,
       origin_timezone: origin_stop.timezone,
-      origin_arrival_time: origin.arrival_time,
-      origin_departure_time: origin.departure_time,
+      origin_arrival_time: origin.arrival_time.presence,
+      origin_departure_time: origin.departure_time.presence,
       # Destination
       destination: destination_stop,
       destination_timezone: destination_stop.timezone,
-      destination_arrival_time: destination.arrival_time,
-      destination_departure_time: destination.departure_time,
+      destination_arrival_time: destination.arrival_time.presence,
+      destination_departure_time: destination.departure_time.presence,
       # Route
       route: route,
       # Trip
-      trip: trip.id,
-      trip_headsign: (origin.stop_headsign || trip.trip_headsign),
-      trip_short_name: trip.trip_short_name,
+      trip: trip.id.presence,
+      trip_headsign: (origin.stop_headsign || trip.trip_headsign).presence,
+      trip_short_name: trip.trip_short_name.presence,
       wheelchair_accessible: trip.wheelchair_accessible.to_i,
       bikes_allowed: trip.bikes_allowed.to_i,
       # Stop Time

--- a/spec/factories/schedule_stop_pair_factory.rb
+++ b/spec/factories/schedule_stop_pair_factory.rb
@@ -56,13 +56,15 @@ FactoryGirl.define do
     association :created_or_updated_in_changeset, factory: :changeset
     version 1
     trip "1234"
+    origin_timezone "America/Los_Angeles"
+    destination_timezone "America/Los_Angeles"
     origin_arrival_time "10:00:00"
     origin_departure_time "10:00:10"
     destination_arrival_time "10:10:00"
     destination_departure_time "10:10:10"
     service_start_date "2000-01-01"
     service_end_date "2100-01-01"
-    service_added_dates [] 
+    service_added_dates []
     service_except_dates []
     service_days_of_week [true, true, true, true, true, false, false] # M - F
   end

--- a/spec/factories/schedule_stop_pair_factory.rb
+++ b/spec/factories/schedule_stop_pair_factory.rb
@@ -31,10 +31,13 @@
 #  bikes_allowed                      :integer
 #  pickup_type                        :integer
 #  drop_off_type                      :integer
-#  timepoint                          :integer
 #  shape_dist_traveled                :float
 #  origin_timezone                    :string
 #  destination_timezone               :string
+#  window_start                       :string
+#  window_end                         :string
+#  origin_timepoint_source            :string
+#  destination_timepoint_source       :string
 #
 # Indexes
 #

--- a/spec/models/schedule_stop_pair_spec.rb
+++ b/spec/models/schedule_stop_pair_spec.rb
@@ -195,5 +195,47 @@ RSpec.describe ScheduleStopPair, type: :model do
       ssp.service_except_dates = [expect_fail]
       expect(ssp.valid?).to be false
     end
-  end  
+  end
+
+  context 'ssp interpolation' do
+    it 'raises unknown interpolation method' do
+      expect { ScheduleStopPair.interpolate([], :unknown) }.to raise_error(ArgumentError)
+    end
+
+    it 'linear interpolation' do
+      ssps = []
+      ssps << build(
+        :schedule_stop_pair,
+        origin_arrival_time: '10:00:00',
+        origin_departure_time: '10:10:00',
+        destination_arrival_time: nil,
+        destination_departure_time: nil
+      )
+      3.times.each do |i|
+        ssps << build(
+          :schedule_stop_pair,
+          origin_arrival_time: nil,
+          origin_departure_time: nil,
+          destination_arrival_time: nil,
+          destination_departure_time: nil
+        )
+      end
+      ssps << build(
+        :schedule_stop_pair,
+        origin_arrival_time: nil,
+        origin_departure_time: nil,
+        destination_arrival_time: '10:40:00',
+        destination_departure_time: '10:50:00'
+      )
+      ScheduleStopPair.interpolate(ssps, :linear)
+      expect(ssps[0].destination_arrival_time).to eq('10:16:00')
+      expect(ssps[1].origin_departure_time).to eq('10:16:00')
+      expect(ssps[1].destination_arrival_time).to eq('10:22:00')
+      expect(ssps[2].origin_departure_time).to eq('10:22:00')
+      expect(ssps[2].destination_arrival_time).to eq('10:28:00')
+      expect(ssps[3].origin_arrival_time).to eq('10:28:00')
+      expect(ssps[3].destination_arrival_time).to eq('10:34:00')
+      expect(ssps[4].origin_departure_time).to eq('10:34:00')
+    end
+  end
 end

--- a/spec/models/schedule_stop_pair_spec.rb
+++ b/spec/models/schedule_stop_pair_spec.rb
@@ -182,18 +182,22 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(ssp.service_on_date?(expect_none)).to be false
     end
 
-    it 'service exceptions must be in service range' do
+    it 'service exceptions outside service_range will be filtered' do
       expect_start = Date.new(2015, 01, 01)
       expect_end = Date.new(2016, 01, 01)
-      expect_fail = Date.new(2020, 01, 01)
-      ssp = build(:schedule_stop_pair, service_start_date: expect_start, service_end_date: expect_end)
-      expect(ssp.valid?).to be true    
-      ssp.service_added_dates = [expect_fail]
-      ssp.service_except_dates = []
-      expect(ssp.valid?).to be false
-      ssp.service_added_dates = []
-      ssp.service_except_dates = [expect_fail]
-      expect(ssp.valid?).to be false
+      expect_unfiltered = Date.new(2015, 06, 01)
+      expect_filtered = Date.new(2020, 01, 01)
+      # Added
+      ssp = build(
+        :schedule_stop_pair,
+        service_start_date: expect_start,
+        service_end_date: expect_end,
+        service_added_dates: [expect_unfiltered, expect_filtered],
+        service_except_dates: [expect_unfiltered, expect_filtered]
+      )
+      expect(ssp.valid?).to be true
+      expect(ssp.service_added_dates).to match_array([expect_unfiltered])
+      expect(ssp.service_except_dates).to match_array([expect_unfiltered])
     end
   end
 

--- a/spec/models/schedule_stop_pair_spec.rb
+++ b/spec/models/schedule_stop_pair_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ScheduleStopPair, type: :model do
   let(:stop1) {create(:stop)}
   let(:stop2) {create(:stop)}
   let(:route) {create(:route)}
-  
+
   context 'has stops' do
     it 'has two stops' do
       ssp = create(:schedule_stop_pair)
@@ -82,7 +82,7 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(destination.stops_in).to match_array([origin])
       expect(destination.stops_out).to be_empty
     end
-  
+
     it 'allows many stop-stop through associations' do
       ssp1 = create(:schedule_stop_pair, origin: stop1, destination: stop2)
       ssp2 = create(:schedule_stop_pair, origin: stop1, destination: stop2)
@@ -90,7 +90,7 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(stop2.trips_in).to match_array([ssp1, ssp2])
     end
   end
-  
+
   context 'changeset' do
     it 'has a changeset' do
       ssp = create(:schedule_stop_pair)
@@ -111,7 +111,7 @@ RSpec.describe ScheduleStopPair, type: :model do
             schedule_stop_pair: ssp_attr
           }
         ]
-      }    
+      }
       changeset = create(:changeset)
       changeset.append(payload)
       changeset.apply!
@@ -137,7 +137,7 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(ScheduleStopPair.where_service_on_date(expect_service).count).to eq(1)
       expect(ScheduleStopPair.where_service_on_date(expect_none).count).to eq(0)
     end
-    
+
     it 'where service from date' do
       expect_start = Date.new(2013, 01, 01)
       expect_end0 = Date.new(2014, 01, 01)
@@ -150,7 +150,7 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(ScheduleStopPair.where_service_from_date(expect_end1).count).to eq(1)
       expect(ScheduleStopPair.where_service_from_date(expect_end2).count).to eq(0)
     end
-    
+
   end
 
   context 'service dates' do
@@ -162,9 +162,9 @@ RSpec.describe ScheduleStopPair, type: :model do
     it 'must have service_end_date' do
       ssp = build(:schedule_stop_pair, service_end_date: nil, service_added_dates: [], service_except_dates: [])
       ssp.service_end_date = nil
-      expect(ssp.valid?).to be false      
+      expect(ssp.valid?).to be false
     end
-    
+
     it 'may set service range from service_added_dates and service_except_dates' do
       expect_start = Date.new(2015, 01, 01)
       expect_end = Date.new(2016, 01, 01)
@@ -243,6 +243,13 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(ssps[3].origin_arrival_time).to eq('10:28:00')
       expect(ssps[3].destination_arrival_time).to eq('10:34:00')
       expect(ssps[4].origin_departure_time).to eq('10:34:00')
+      # Check window
+      expect(ssps[1].window_start).to eq(ssps[0].origin_departure_time)
+      expect(ssps[1].window_end).to eq(ssps[4].destination_arrival_time)
+      # Check interpolation method
+      expect(ssps[0].origin_timepoint_source).to eq('gtfs_exact')
+      expect(ssps[0].destination_timepoint_source).to eq('transitland_interpolated_linear')
+      expect(ssps[4].destination_timepoint_source).to eq('gtfs_exact')
     end
   end
 end

--- a/spec/models/schedule_stop_pair_spec.rb
+++ b/spec/models/schedule_stop_pair_spec.rb
@@ -31,10 +31,13 @@
 #  bikes_allowed                      :integer
 #  pickup_type                        :integer
 #  drop_off_type                      :integer
-#  timepoint                          :integer
 #  shape_dist_traveled                :float
 #  origin_timezone                    :string
 #  destination_timezone               :string
+#  window_start                       :string
+#  window_end                         :string
+#  origin_timepoint_source            :string
+#  destination_timepoint_source       :string
 #
 # Indexes
 #

--- a/spec/services/gtfsgraph_spec.rb
+++ b/spec/services/gtfsgraph_spec.rb
@@ -107,8 +107,10 @@ describe GTFSGraph do
       expect(s.service_except_dates.map(&:to_s)).to contain_exactly('2015-06-06', '2015-07-04')
       expect(s.service_start_date.to_s).to eq('2015-05-02')
       expect(s.service_end_date.to_s).to eq('2024-10-05')
+      expect(s.origin_timepoint_source).to eq('gtfs_exact')
+      expect(s.destination_timepoint_source).to eq('gtfs_exact')
+      expect(s.window_start).to eq('08:15:00')
+      expect(s.window_end).to eq('08:20:00')
     end
-
   end
-
 end

--- a/spec/services/gtfsgraph_spec.rb
+++ b/spec/services/gtfsgraph_spec.rb
@@ -92,7 +92,6 @@ describe GTFSGraph do
       expect(s.origin_timezone).to eq('America/Los_Angeles')
       expect(s.destination_timezone).to eq('America/Los_Angeles')
       expect(s.shape_dist_traveled).to eq(0.0)
-      expect(s.timepoint).to be_nil
       expect(s.block_id).to be_nil
       expect(s.wheelchair_accessible).to eq(0)
       expect(s.pickup_type).to eq(0)


### PR DESCRIPTION
 * Extensible ScheduleStopPair interpolation method
 * Bump gtfs version, various bugfixes
 * Additional ScheduleStopPair validations; factory updates
 * Pass SSP o/d times through WideTime parsing
 * SSP interpolation unit test
 * SSP now filters out service exception dates outside of service range
 * gtfsgraph works with SSP instances instead of hashes