### PR TITLE
cosmetic updates for locate service changes

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -213,7 +213,7 @@ class Stop < BaseStop
         end
         tyr_locate_response = TyrService.locate(locations: locations)
         group.each_with_index do |stop, index|
-          way_id = tyr_locate_response[index][:ways][0][:way_id]
+          way_id = tyr_locate_response[index][:edges][0][:way_id]
           stop_tags = stop.tags.try(:clone) || {}
           stop_tags[:osm_way_id] = way_id
           stop.update(tags: stop_tags)

--- a/spec/services/tyr_service_spec.rb
+++ b/spec/services/tyr_service_spec.rb
@@ -16,11 +16,23 @@ describe TyrService do
       expect(response).to eq [
         {
           input_lon: -122.413605,
-          ways: [{
-            correlated_lon: -122.413605,
-            way_id: 8917801,
-            correlated_lat: 37.775692
-          }],
+          node: nil,
+          edges:[
+            {
+              way_id: 8917801,
+              correlated_lat: 37.775589,
+              side_of_street: "left",
+              percent_along: 0.39047,
+              correlated_lon: -122.413521
+            },
+            {
+              way_id: 8917801,
+              correlated_lat: 37.775589,
+              side_of_street: "right",
+              percent_along: 0.60953,
+              correlated_lon: -122.413521
+            }
+          ],
           input_lat: 37.775692
         }
       ]
@@ -42,19 +54,43 @@ describe TyrService do
       expect(response).to eq [
         {
           input_lon: -122.413605,
-          ways: [{
-            correlated_lon: -122.413605,
-            way_id: 8917801,
-            correlated_lat: 37.775692
-          }],
+          node: null,
+          edges: [
+          {
+             way_id: 8917801,
+             correlated_lat: 37.775589,
+             side_of_street: "left",
+             percent_along: 0.39047,
+             correlated_lon: -122.413521
+          },
+          {
+             way_id: 8917801,
+             correlated_lat: 37.775589,
+             side_of_street: "right",
+             percent_along: 0.60953,
+             correlated_lon: -122.413521
+          }
+          ],
           input_lat: 37.775692
         },{
           input_lon: -73.990471,
-          ways: [{
-            correlated_lon: -73.990471,
-            way_id: 5671311,
-            correlated_lat: 40.744549
-          }],
+          node: null,
+          edges: [
+          {
+             way_id: 5671311,
+             correlated_lat: 40.744427,
+             side_of_street: "right",
+             percent_along: 0.87621,
+             correlated_lon: -73.990524
+          },
+          {
+             way_id: 5671311,
+             correlated_lat: 40.744427,
+             side_of_street: "left",
+             percent_along: 0.12379,
+             correlated_lon: -73.990524
+          }
+          ],
           input_lat: 40.744549
         }
       ]

--- a/spec/services/tyr_service_spec.rb
+++ b/spec/services/tyr_service_spec.rb
@@ -54,7 +54,7 @@ describe TyrService do
       expect(response).to eq [
         {
           input_lon: -122.413605,
-          node: null,
+          node: nil,
           edges: [
           {
              way_id: 8917801,
@@ -74,7 +74,7 @@ describe TyrService do
           input_lat: 37.775692
         },{
           input_lon: -73.990471,
-          node: null,
+          node: nil,
           edges: [
           {
              way_id: 5671311,

--- a/spec/support/vcr_cassettes/tyr_one_location.yml
+++ b/spec/support/vcr_cassettes/tyr_one_location.yml
@@ -18,33 +18,25 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Headers:
-      - Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD
       Access-Control-Allow-Origin:
       - "*"
-      Access-Control-Expose-Headers:
-      - content-type, content-length, X-ApiaxleProxy-Qps-Left, X-ApiaxleProxy-Qpd-Left
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Thu, 28 May 2015 18:45:07 GMT
+      - Wed, 07 Oct 2015 17:46:11 GMT
       Server:
       - nginx/1.4.6 (Ubuntu)
       X-Apiaxleproxy-Qpd-Left:
-      - '19999'
+      - '999999'
       X-Apiaxleproxy-Qps-Left:
-      - '1'
+      - '99'
       Content-Length:
-      - '133'
+      - '318'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: '[{"input_lon":-122.413605,"node":null,"edges":[{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"left","percent_along":0.39047,"correlated_lon":-122.413521},{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"right","percent_along":0.60953,"correlated_lon":-122.413521}],"input_lat":37.775692}]'
     http_version:
-  recorded_at: Thu, 28 May 2015 18:45:11 GMT
+  recorded_at: Wed, 07 Oct 2015 17:46:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/support/vcr_cassettes/tyr_one_location.yml
+++ b/spec/support/vcr_cassettes/tyr_one_location.yml
@@ -44,7 +44,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"input_lon":-122.413605,"ways":[{"correlated_lon":-122.413605,"way_id":8917801,"correlated_lat":37.775692}],"input_lat":37.775692}]'
+      string: '[{"input_lon":-122.413605,"node":null,"edges":[{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"left","percent_along":0.39047,"correlated_lon":-122.413521},{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"right","percent_along":0.60953,"correlated_lon":-122.413521}],"input_lat":37.775692}]'
     http_version:
   recorded_at: Thu, 28 May 2015 18:45:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/support/vcr_cassettes/tyr_two_locations.yml
+++ b/spec/support/vcr_cassettes/tyr_two_locations.yml
@@ -44,7 +44,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '[{"input_lon":-122.413605,"ways":[{"correlated_lon":-122.413605,"way_id":8917801,"correlated_lat":37.775692}],"input_lat":37.775692},{"input_lon":-73.990471,"ways":[{"correlated_lon":-73.990471,"way_id":5671311,"correlated_lat":40.744549}],"input_lat":40.744549}]'
+      string: '[{"input_lon":-122.413605,"node":null,"edges":[{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"left","percent_along":0.39047,"correlated_lon":-122.413521},{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"right","percent_along":0.60953,"correlated_lon":-122.413521}],"input_lat":37.775692},{"input_lon":-73.990471,"node":null,"edges":[{"way_id":5671311,"correlated_lat":40.744427,"side_of_street":"right","percent_along":0.87621,"correlated_lon":-73.990524},{"way_id":5671311,"correlated_lat":40.744427,"side_of_street":"left","percent_along":0.12379,"correlated_lon":-73.990524}],"input_lat":40.744549}]'
     http_version:
   recorded_at: Thu, 28 May 2015 18:45:11 GMT
 recorded_with: VCR 2.9.3

--- a/spec/support/vcr_cassettes/tyr_two_locations.yml
+++ b/spec/support/vcr_cassettes/tyr_two_locations.yml
@@ -18,33 +18,25 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Headers:
-      - Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD
       Access-Control-Allow-Origin:
       - "*"
-      Access-Control-Expose-Headers:
-      - content-type, content-length, X-ApiaxleProxy-Qps-Left, X-ApiaxleProxy-Qpd-Left
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Thu, 28 May 2015 18:45:08 GMT
+      - Wed, 07 Oct 2015 17:46:11 GMT
       Server:
       - nginx/1.4.6 (Ubuntu)
       X-Apiaxleproxy-Qpd-Left:
-      - '19998'
+      - '999998'
       X-Apiaxleproxy-Qps-Left:
-      - '1'
+      - '98'
       Content-Length:
-      - '263'
+      - '632'
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
       string: '[{"input_lon":-122.413605,"node":null,"edges":[{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"left","percent_along":0.39047,"correlated_lon":-122.413521},{"way_id":8917801,"correlated_lat":37.775589,"side_of_street":"right","percent_along":0.60953,"correlated_lon":-122.413521}],"input_lat":37.775692},{"input_lon":-73.990471,"node":null,"edges":[{"way_id":5671311,"correlated_lat":40.744427,"side_of_street":"right","percent_along":0.87621,"correlated_lon":-73.990524},{"way_id":5671311,"correlated_lat":40.744427,"side_of_street":"left","percent_along":0.12379,"correlated_lon":-73.990524}],"input_lat":40.744549}]'
     http_version:
-  recorded_at: Thu, 28 May 2015 18:45:11 GMT
+  recorded_at: Wed, 07 Oct 2015 17:46:13 GMT
 recorded_with: VCR 2.9.3

--- a/spec/workers/conflate_stops_with_osm_worker_spec.rb
+++ b/spec/workers/conflate_stops_with_osm_worker_spec.rb
@@ -17,15 +17,15 @@ describe ConflateStopsWithOsmWorker do
             correlated_lon: -122.413601,
             way_id: 8917801,
             correlated_lat: 37.775692,
-            side_of_street: "right",
-            percent_along: .63
+            side_of_street: 'right',
+            percent_along: 0.63
           },
           {
             correlated_lon: -122.413601,
             way_id: 8917801,
             correlated_lat: 37.775692,
-            side_of_street: "left",
-            percent_along: .37
+            side_of_street: 'left',
+            percent_along: 0.37
           }
         ]
       },
@@ -38,15 +38,15 @@ describe ConflateStopsWithOsmWorker do
             correlated_lon: -122.413601,
             way_id: 8917802,
             correlated_lat: 37.775692
-            side_of_street: "right",
-            percent_along: .82
+            side_of_street: 'right',
+            percent_along: 0.82
           },
           {
             correlated_lon: -122.413601,
             way_id: 8917802,
             correlated_lat: 37.775692
-            side_of_street: "left",
-            percent_along: .18
+            side_of_street: 'left',
+            percent_along: 0.18
           }
         ]
       }

--- a/spec/workers/conflate_stops_with_osm_worker_spec.rb
+++ b/spec/workers/conflate_stops_with_osm_worker_spec.rb
@@ -37,14 +37,14 @@ describe ConflateStopsWithOsmWorker do
           {
             correlated_lon: -122.413601,
             way_id: 8917802,
-            correlated_lat: 37.775692
+            correlated_lat: 37.775692,
             side_of_street: 'right',
             percent_along: 0.82
           },
           {
             correlated_lon: -122.413601,
             way_id: 8917802,
-            correlated_lat: 37.775692
+            correlated_lat: 37.775692,
             side_of_street: 'left',
             percent_along: 0.18
           }

--- a/spec/workers/conflate_stops_with_osm_worker_spec.rb
+++ b/spec/workers/conflate_stops_with_osm_worker_spec.rb
@@ -11,20 +11,44 @@ describe ConflateStopsWithOsmWorker do
       {
         input_lon: -122.413601,
         input_lat: 37.775692,
-        ways: [{
-          correlated_lon: -122.413601,
-          way_id: 8917801,
-          correlated_lat: 37.775692
-        }]
+        node: nil,
+        edges: [
+          {
+            correlated_lon: -122.413601,
+            way_id: 8917801,
+            correlated_lat: 37.775692,
+            side_of_street: "right",
+            percent_along: .63
+          },
+          {
+            correlated_lon: -122.413601,
+            way_id: 8917801,
+            correlated_lat: 37.775692,
+            side_of_street: "left",
+            percent_along: .37
+          }
+        ]
       },
       {
         input_lon: -122.396431,
         input_lat: 37.793152,
-        ways: [{
-          correlated_lon: -122.413601,
-          way_id: 8917802,
-          correlated_lat: 37.775692
-        }]
+        node: nil,
+        edges: [
+          {
+            correlated_lon: -122.413601,
+            way_id: 8917802,
+            correlated_lat: 37.775692
+            side_of_street: "right",
+            percent_along: .82
+          },
+          {
+            correlated_lon: -122.413601,
+            way_id: 8917802,
+            correlated_lat: 37.775692
+            side_of_street: "left",
+            percent_along: .18
+          }
+        ]
       }
     ])
     worker = ConflateStopsWithOsmWorker.new


### PR DESCRIPTION
the output of locate now looks a bit different:

    [
        {
            "input_lon": -1.783433,
            "node": null,
            "edges": [
                {
                    "way_id": 24187895,
                    "correlated_lat": 53.475826,
                    "side_of_street": "left",
                    "percent_along": 0.54,
                    "correlated_lon": -1.783387
                },
                {
                    "way_id": 24187895,
                    "correlated_lat": 53.475826,
                    "side_of_street": "right",
                    "percent_along": 0.46,
                    "correlated_lon": -1.783387
                }
            ],
            "input_lat": 53.475735
        }
    ]

instead of collapsing everything based on way_id we instead return all the graph edges, hence the only change for transitland is 'ways' -> 'edges'