### PR TITLE
Feed update bbox

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -182,17 +182,10 @@ class Feed < BaseFeed
     feeds_with_updated_versions
   end
 
-  def set_bounding_box_from_gtfs_stops
-    gtfs = GTFS::Source.build(file_path, {strict: false})
-    stop_points = []
-    gtfs.each_stop do |stop|
-      stop_points << Stop::GEOFACTORY.point(stop.stop_lon, stop.stop_lat)
-    end
-    stop_features = Stop::GEOFACTORY.collection(stop_points)
+  def set_bounding_box_from_stops(stops)
+    stop_features = Stop::GEOFACTORY.collection(stops.map { |stop| stop.geometry(as: :wkt) })
     bounding_box = RGeo::Cartesian::BoundingBox.create_from_geometry(stop_features)
-    # TODO: Feed geometry should be written through a changeset. Refactor!
     self.geometry = bounding_box.to_geometry
-    self.save!
   end
 
   private

--- a/app/workers/feed_eater_feed_worker.rb
+++ b/app/workers/feed_eater_feed_worker.rb
@@ -31,9 +31,6 @@ class FeedEaterFeedWorker < FeedEaterWorker
       feed_import.update(validation_report: validation_report)
     end
 
-    # Set feed bounding box
-    feed.set_bounding_box_from_gtfs_stops
-
     # Import feed
     logger.info "FeedEaterFeedWorker #{feed_onestop_id}: Importing feed at import level #{import_level}"
     graph = nil

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -157,6 +157,11 @@ class GTFSGraph
     action = 'createUpdate'
     changeset = Changeset.create()
 
+    # Update Feed Bounding Box
+    log "  updating feed bounding box"
+    @feed.set_bounding_box_from_stops(stops)
+    @feed.save!
+
     # Operators
     if import_level >= 0
       counter = 0

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -160,6 +160,7 @@ class GTFSGraph
     # Update Feed Bounding Box
     log "  updating feed bounding box"
     @feed.set_bounding_box_from_stops(stops)
+    # FIXME: Run through changeset
     @feed.save!
 
     # Operators

--- a/lib/gtfsgraph.rb
+++ b/lib/gtfsgraph.rb
@@ -418,6 +418,7 @@ if __FILE__ == $0
   filename = "tmp/transitland-feed-data/#{feedid}.zip"
   import_level = (ARGV[1] || 1).to_i
   feed = Feed.find_by!(onestop_id: feedid)
+  feed.fetch_and_check_for_updated_version unless File.exists?(filename)
   graph = GTFSGraph.new(filename, feed)
   operators = graph.load_tl
   graph.create_changeset(operators, import_level=import_level)

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -189,33 +189,22 @@ describe Feed do
   end
 
   it 'gets a bounding box around all its stops' do
-    feed = create(:feed_caltrain)
-    allow(feed).to receive(:file_path) { 'spec/support/example_gtfs_archives/f-9q9-caltrain.zip' }
-    feed.set_bounding_box_from_gtfs_stops
-    expect(feed.geometry).to eq({
-      type: 'Polygon',
+    feed = build(:feed)
+    stops = []
+    stops << build(:stop, geometry: "POINT (-121.902181 37.329392)")
+    stops << build(:stop, geometry: "POINT (-122.030742 37.378427)")
+    stops << build(:stop, geometry: "POINT (-122.076327 37.393879)")
+    stops << build(:stop, geometry: "POINT (-122.1649 37.44307)")
+    feed.set_bounding_box_from_stops(stops)
+    expect(feed.geometry(as: :geojson)).to eq({
+      type: "Polygon",
       coordinates: [
         [
-          [
-            -122.412076,
-            37.003485
-          ],
-          [
-            -121.566088,
-            37.003485
-          ],
-          [
-            -121.566088,
-            37.776439
-          ],
-          [
-            -122.412076,
-            37.776439
-          ],
-          [
-            -122.412076,
-            37.003485
-          ]
+          [-122.1649, 37.329392],
+          [-121.902181, 37.329392],
+          [-121.902181, 37.44307],
+          [-122.1649, 37.44307],
+          [-122.1649, 37.329392]
         ]
       ]
     })

--- a/spec/services/gtfsgraph_spec.rb
+++ b/spec/services/gtfsgraph_spec.rb
@@ -15,6 +15,19 @@ describe GTFSGraph do
 
     before(:each) { @feed = load_feed(1) }
 
+    it 'updated feed geometry' do
+      geometry = [
+        [
+          [-122.412018, 37.003606],
+          [-121.566497, 37.003606],
+          [-121.566497, 37.776439],
+          [-122.412018, 37.776439],
+          [-122.412018, 37.003606]
+        ]
+      ]
+      expect(@feed.geometry(as: :geojson)[:coordinates]).to match_array(geometry)
+    end
+
     it 'created a known Operator' do
       expect(@feed.operators.count).to eq(1)
       o = @feed.operators.find_by(onestop_id: 'o-9q9-caltrain')


### PR DESCRIPTION
 * Feed#set_bounding_box_from_gtfs_stops renamed to Feed#set_bounding_box_from_stops
 * Updated to work with any entity with geometry.
 * Saving also now handled externally.
 * Updated gtfsgraph to set Feed bbox while creating operator/route/stop changesets. 
 * Updated unit and integration tests.