### PR TITLE
Auto conflating stops

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -38,7 +38,7 @@ class Stop < BaseStop
   self.table_name_prefix = 'current_'
 
   GEOHASH_PRECISION = 10
-  MAX_HOURS_SINCE_LAST_CONFLATE = 2
+  MAX_HOURS_SINCE_LAST_CONFLATE = 84
 
   include HasAOnestopId
   include IsAnEntityWithIdentifiers

--- a/app/serializers/stop_serializer.rb
+++ b/app/serializers/stop_serializer.rb
@@ -13,6 +13,7 @@
 #  version                            :integer
 #  identifiers                        :string           default([]), is an Array
 #  timezone                           :string
+#  last_conflated_at                  :datetime
 #
 # Indexes
 #

--- a/config/sample.application.yml
+++ b/config/sample.application.yml
@@ -5,6 +5,7 @@ TRANSITLAND_FEED_REGISTRY_PATH: <%= Rails.root.join('tmp', 'transitland-feed-reg
 TRANSITLAND_FEED_DATA_PATH: <%= Rails.root.join('tmp', 'transitland-feed-data') %>
 TRANSITLAND_DATASTORE_HOST: http://localhost:3000
 AUTO_CONFLATE_STOPS_WITH_OSM: 'true'
+MAX_HOURS_SINCE_LAST_CONFLATE: '84'
 TYR_AUTH_TOKEN: 'get one from mapzen.com/developers'
 ATTACHMENTS_S3_REGION: 'us-east-1'
 ATTACHMENTS_S3_BUCKET: 'name of an S3 bucket'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,7 @@ every 1.day, at: '12:01 pm' do
   runner 'Feed.async_fetch_all_feeds'
 end
 
-# Every Sunday and Wednesday at 12:01 AM
-every '1 0 * * 0,3' do
+# Every day at 12:01 AM
+every '1 0 * * *' do
   runner 'Stop.re_conflate_with_osm'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,6 @@ every 1.day, at: '12:01 pm' do
   runner 'Feed.async_fetch_all_feeds'
 end
 
-# Every day at 12:01 AM
-every '1 0 * * *' do
+every 1.day, at: '12:01 am' do
   runner 'Stop.re_conflate_with_osm'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -8,3 +8,8 @@
 every 1.day, at: '12:01 pm' do
   runner 'Feed.async_fetch_all_feeds'
 end
+
+# Every Sunday and Wednesday at 12:01 AM
+every '1 0 * * 0,3' do
+  runner 'Stop.re_conflate_with_osm'
+end

--- a/db/migrate/20151106195645_add_last_conflate_to_stops.rb
+++ b/db/migrate/20151106195645_add_last_conflate_to_stops.rb
@@ -1,0 +1,6 @@
+class AddLastConflateToStops < ActiveRecord::Migration
+  def change
+    add_column :current_stops, :last_conflated_at, :datetime
+    add_column :old_stops, :last_conflated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151030234052) do
+ActiveRecord::Schema.define(version: 20151106195645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(version: 20151030234052) do
     t.integer   "version"
     t.string    "identifiers",                                                                                    default: [], array: true
     t.string    "timezone"
+    t.datetime  "last_conflated_at"
   end
 
   add_index "current_stops", ["created_or_updated_in_changeset_id"], name: "#c_stops_cu_in_changeset_id_index", using: :btree
@@ -468,6 +469,7 @@ ActiveRecord::Schema.define(version: 20151030234052) do
     t.integer   "version"
     t.string    "identifiers",                                                                                    default: [], array: true
     t.string    "timezone"
+    t.datetime  "last_conflated_at"
   end
 
   add_index "old_stops", ["created_or_updated_in_changeset_id"], name: "o_stops_cu_in_changeset_id_index", using: :btree

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -12,3 +12,4 @@ key | possible values | default | description
 `RUN_GOOGLE_FEEDVALIDATOR` | `true`, `false` | `true` | By default, FeedEaterWorker will validate feeds using the [Google transitfeed Python library](https://github.com/google/transitfeed). Set to `false` in order to skip this step.
 `ATTACHMENTS_S3_REGION` | [any AWS S3 region](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region) | `us-east-1` | used for uploading FeedEater artifacts
 `ATTACHMENTS_S3_BUCKET` | name of an AWS S3 bucket | none | used for uploading FeedEater artifacts
+`MAX_HOURS_SINCE_LAST_CONFLATE` | Any real number >= 0 | 84 hours | Stops that were last conflated before this number of hours before the re-conflation check time will be re-conflated.

--- a/spec/factories/stop_factory.rb
+++ b/spec/factories/stop_factory.rb
@@ -13,6 +13,7 @@
 #  version                            :integer
 #  identifiers                        :string           default([]), is an Array
 #  timezone                           :string
+#  last_conflated_at                  :datetime
 #
 # Indexes
 #

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -148,7 +148,6 @@ describe Stop do
       expect {
         Stop.re_conflate_with_osm(2.hours.ago)
       }.to change(ConflateStopsWithOsmWorker.jobs, :size).by(1)
-      Sidekiq::Worker.clear_all
     end
 
     it '.conflate_with_osm' do

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -13,6 +13,7 @@
 #  version                            :integer
 #  identifiers                        :string           default([]), is an Array
 #  timezone                           :string
+#  last_conflated_at                  :datetime
 #
 # Indexes
 #

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -144,11 +144,11 @@ describe Stop do
     end
 
     it '.re_conflate_with_osm' do
-      pending 'write some specs'
+      #pending 'write some specs'
     end
 
     it '.conflate_with_osm' do
-      pending 'write some specs'
+      #pending 'write some specs'
     end
   end
 

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -136,6 +136,22 @@ describe Stop do
     end
   end
 
+  context 'conflation' do
+    it 'finds stops that have not been conflated since' do
+      stop1 = create(:stop, last_conflated_at: 1.hours.ago)
+      stop2 = create(:stop, last_conflated_at: 3.hours.ago)
+      expect(Stop.last_conflated_before(2.hours.ago)).to match_array([stop2])
+    end
+
+    it '.re_conflate_with_osm' do
+      pending 'write some specs'
+    end
+
+    it '.conflate_with_osm' do
+      pending 'write some specs'
+    end
+  end
+
   context 'diff_against' do
     pending 'write some specs'
   end

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -144,7 +144,11 @@ describe Stop do
     end
 
     it '.re_conflate_with_osm' do
-      #pending 'write some specs'
+      stop1 = create(:stop, last_conflated_at: 3.hours.ago)
+      expect {
+        Stop.re_conflate_with_osm(2.hours.ago)
+      }.to change(ConflateStopsWithOsmWorker.jobs, :size).by(1)
+      Sidekiq::Worker.clear_all
     end
 
     it '.conflate_with_osm' do


### PR DESCRIPTION
The datastore can now be configured, via cron in config/schedule.rb, to re-conflate stops with OSM at specified regular intervals. 

The default interval is 2x per week, Sunday and Wednesday at 12:01am.