### PR TITLE
fixing crontab on servers

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,6 +5,8 @@
 #
 # Learn more: http://github.com/javan/whenever
 
+job_type :runner, "cd :path && bin/bundle exec rails runner -e :environment ':task' :output"
+
 every 1.day, at: '12:01 pm' do
   runner 'Feed.async_fetch_all_feeds'
 end


### PR DESCRIPTION
By default, the crontab entries that the Whenever gem produces don't wrap commands in `bundle exec`. The commands were failing on both dev and prod stacks. This change will hopefully fix the problem.