### PR TITLE
reduce Sidekiq concurrency on dev stack

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,7 @@
 ---
 :concurrency: 5
 staging:
-  :concurrency: 20
+  :concurrency: 5
 production:
   :concurrency: 20
 :limits:


### PR DESCRIPTION
We've been running out of database connections on the dev stack, probably because we're spinning up multiple background worker nodes. If each has 20 DB connections, that will max out the small RDS instance on the dev stack.

TODO: In the future, figure out the appropriate concurrency number for production. Maybe it has to be dynamically dependent on the number of worker nodes.