### PR TITLE
`ScheduleStopPair.where_origin_bbox` method now runs one query

### DIFF
--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -129,8 +129,8 @@ class ScheduleStopPair < BaseScheduleStopPair
 
   # Service trips_out in a bbox
   scope :where_origin_bbox, -> (bbox) {
-    stops = Stop.within_bbox(bbox)
-    where(origin: stops)
+    # use Squeel gem to run a subquery
+    where{origin_id.in(Stop.within_bbox(bbox).select{id})}
   }
 
   # Handle mapping from onestop_id to id


### PR DESCRIPTION
instead of two

Uses the Squeel gem to run a subquery: https://github.com/activerecord-hackery/squeel#subqueries