### PR TITLE
Routes by stops bounding box

### DIFF
--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::FeedsController < Api::V1::BaseApiController
     elsif params[:tag_key].present?
       @feeds = @feeds.with_tag(params[:tag_key])
     elsif params[:bbox].present?
-      @feeds = @feeds.within_bbox(params[:bbox])
+      @feeds = @feeds.geometry_within_bbox(params[:bbox])
     end
 
     @feeds = @feeds.includes{[operators_in_feed]}

--- a/app/controllers/api/v1/operators_controller.rb
+++ b/app/controllers/api/v1/operators_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::OperatorsController < Api::V1::BaseApiController
       @operators = @operators.where{st_dwithin(geometry, point, r)}.order{st_distance(geometry, point)}
     end
     if params[:bbox].present?
-      @operators = @operators.within_bbox(params[:bbox])
+      @operators = @operators.geometry_within_bbox(params[:bbox])
     end
     if params[:onestop_id].present?
       @operators = @operators.where(onestop_id: params[:onestop_id])

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       @routes = @routes.operated_by(params[:operatedBy])
     end
     if params[:bbox].present?
-      @routes = @routes.where_stop_within_bbox(params[:bbox])
+      @routes = @routes.stop_within_bbox(params[:bbox])
     end
     if params[:onestop_id].present?
       @routes = @routes.where(onestop_id: params[:onestop_id])

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       @routes = @routes.operated_by(params[:operatedBy])
     end
     if params[:bbox].present?
-      @routes = @routes.where_has_stop_within_bbox(params[:bbox])
+      @routes = @routes.where_stop_within_bbox(params[:bbox])
     end
     if params[:onestop_id].present?
       @routes = @routes.where(onestop_id: params[:onestop_id])

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       @routes = @routes.operated_by(params[:operatedBy])
     end
     if params[:bbox].present?
-      @routes = @routes.within_bbox(params[:bbox])
+      @routes = @routes.where_has_stop_within_bbox(params[:bbox])
     end
     if params[:onestop_id].present?
       @routes = @routes.where(onestop_id: params[:onestop_id])

--- a/app/controllers/api/v1/stops_controller.rb
+++ b/app/controllers/api/v1/stops_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::StopsController < Api::V1::BaseApiController
       @stops = @stops.where{st_dwithin(geometry, point, r)}.order{st_distance(geometry, point)}
     end
     if params[:bbox].present?
-      @stops = @stops.within_bbox(params[:bbox])
+      @stops = @stops.geometry_within_bbox(params[:bbox])
     end
     if params[:onestop_id].present?
       @stops = @stops.where(onestop_id: params[:onestop_id])

--- a/app/models/concerns/has_a_geographic_geometry.rb
+++ b/app/models/concerns/has_a_geographic_geometry.rb
@@ -4,7 +4,7 @@ module HasAGeographicGeometry
   included do
     GEOFACTORY ||= RGeo::Geographic.spherical_factory(srid: 4326)
 
-    scope :within_bbox, -> (bbox_coordinates) {
+    scope :geometry_within_bbox, -> (bbox_coordinates) {
       if bbox_coordinates.is_a?(String)
         bbox_coordinates = bbox_coordinates.split(',').map(&:strip)
       end

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -135,6 +135,7 @@ class Route < BaseRoute
   }
 
   scope :where_stop_within_bbox, -> (bbox) {
+    #joins(routes_serving_stop: :stop).merge(Stop.within_bbox(bbox))
     where(id: RouteServingStop.select(:route_id).where(stop: Stop.within_bbox(bbox)))
   }
 

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -135,7 +135,6 @@ class Route < BaseRoute
   }
 
   scope :where_stop_within_bbox, -> (bbox) {
-    #joins(routes_serving_stop: :stop).merge(Stop.within_bbox(bbox))
     where(id: RouteServingStop.select(:route_id).where(stop: Stop.within_bbox(bbox)))
   }
 

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -134,7 +134,7 @@ class Route < BaseRoute
     end
   }
 
-  scope :where_has_stop_within_bbox, -> (bbox) {
+  scope :where_stop_within_bbox, -> (bbox) {
     where(id: RouteServingStop.select(:route_id).where(stop: Stop.within_bbox(bbox)))
   }
 

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -134,7 +134,7 @@ class Route < BaseRoute
     end
   }
 
-  scope :where_stop_within_bbox, -> (bbox) {
+  scope :stop_within_bbox, -> (bbox) {
     where(id: RouteServingStop.select(:route_id).where(stop: Stop.within_bbox(bbox)))
   }
 

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -135,7 +135,7 @@ class Route < BaseRoute
   }
 
   scope :stop_within_bbox, -> (bbox) {
-    where(id: RouteServingStop.select(:route_id).where(stop: Stop.within_bbox(bbox)))
+    where(id: RouteServingStop.select(:route_id).where(stop: Stop.geometry_within_bbox(bbox)))
   }
 
   ##### FromGTFS ####

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -134,6 +134,10 @@ class Route < BaseRoute
     end
   }
 
+  scope :where_has_stop_within_bbox, -> (bbox) {
+    where(id: RouteServingStop.select(:route_id).where(stop: Stop.within_bbox(bbox)))
+  }
+
   ##### FromGTFS ####
   include FromGTFS
   def self.from_gtfs(entity, stops)

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -129,7 +129,7 @@ class ScheduleStopPair < BaseScheduleStopPair
 
   # Service trips_out in a bbox
   scope :where_origin_bbox, -> (bbox) {
-    stops = Stop.within_bbox(bbox)
+    stops = Stop.geometry_within_bbox(bbox)
     where(origin: stops)
   }
 

--- a/spec/controllers/api/v1/routes_controller_spec.rb
+++ b/spec/controllers/api/v1/routes_controller_spec.rb
@@ -12,6 +12,14 @@ describe Api::V1::RoutesController do
         type: 'MultiLineString'
       }
     )
+    point = Stop::GEOFACTORY.point(-122.38666,37.599787)
+    millbrae = create(
+      :stop,
+      onestop_id: "s-9q8vzhbf8h-millbrae",
+      name: "Millbrae",
+      geometry: point.to_s,
+    )
+    rsp = create(:route_serving_stop, route_id: @richmond_millbrae_route.id, stop_id: millbrae.id)
   end
 
   describe 'GET index' do
@@ -47,8 +55,8 @@ describe Api::V1::RoutesController do
         }})
       end
 
-      it 'returns no routes when none in bounding box' do
-        get :index, bbox: '-122.25783348083498,37.61280361684656,-122.17955589294435,37.64611177340781'
+      it 'returns no routes when no route stops in bounding box' do
+        get :index, bbox: '-122.353165,37.936887,-122.2992715,37.9030588'
         expect_json({ routes: -> (routes) {
           expect(routes.length).to eq 0
         }})

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -50,4 +50,8 @@ describe Route do
     expect(Route.operated_by(bart)).to match_array([route1])
     expect(Route.operated_by(sfmta.onestop_id)).to match_array([route2])
   end
+
+  it 'can be found when has stop within bbox query' do
+    
+  end
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -51,7 +51,7 @@ describe Route do
     expect(Route.operated_by(sfmta.onestop_id)).to match_array([route2])
   end
 
-  it 'can be found when has stop within bbox query' do
+  it 'can be found only when has stop within bbox query' do
     point = Stop::GEOFACTORY.point(-122.0, 35.0)
     stop = create(:stop, geometry: point.to_s)
     geojson = {

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -76,9 +76,9 @@ describe Route do
     end
 
     it 'has geometry within bbox' do
-      expect(Route.within_bbox(@bbox_should_contain_stop_not_geom)).to match_array([])
-      expect(Route.within_bbox(@bbox_should_neither_contain_stop_nor_geom)).to match_array([])
-      expect(Route.within_bbox(@bbox_should_contain_geom_only)).to match_array([@route])
+      expect(Route.geometry_within_bbox(@bbox_should_contain_stop_not_geom)).to match_array([])
+      expect(Route.geometry_within_bbox(@bbox_should_neither_contain_stop_nor_geom)).to match_array([])
+      expect(Route.geometry_within_bbox(@bbox_should_contain_geom_only)).to match_array([@route])
     end
   end
 

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -51,23 +51,35 @@ describe Route do
     expect(Route.operated_by(sfmta.onestop_id)).to match_array([route2])
   end
 
-  it 'can be found only when has stop within bbox query' do
-    point = Stop::GEOFACTORY.point(-122.0, 35.0)
-    stop = create(:stop, geometry: point.to_s)
-    geojson = {
-      type: 'MultiLineString',
-      coordinates: [
-        [[-73.87481689453125, 40.88860081193033],[ -73.9764404296875, 40.763901280945866],[ -73.94622802734375, 40.686886382151116],[ -73.9544677734375, 40.61186744303007]],
-        [[-74.1851806640625,40.81588791441588],[-74.00665283203124,40.83251504043271],[-73.948974609375,40.7909394098518],[-73.8006591796875,40.751418432997426],[-73.4326171875,40.79301881008675]]
-      ]
-    }
-    route = create(:route, geometry: geojson)
-    rsp = create(:route_serving_stop, route_id: route.id, stop_id: stop.id)
-    bbox1 = [-121.0,34.0,-123.0,36.0]
-    bbox2 = [-125.0,34.0,-123.0,36.0]
-    bbox3 = [-73.87481689453125,40.88860081193033,-73.94622802734375,40.686886382151116]
-    expect(Route.where_stop_within_bbox(bbox1)).to match_array([route])
-    expect(Route.where_stop_within_bbox(bbox2)).to match_array([])
-    expect(Route.where_stop_within_bbox(bbox3)).to match_array([])
+  context 'within bbox' do
+    before(:each) do
+      point = Stop::GEOFACTORY.point(-122.0, 35.0)
+      stop = create(:stop, geometry: point.to_s)
+      geojson = {
+        type: 'MultiLineString',
+        coordinates: [
+          [[-73.87481689453125, 40.88860081193033],[ -73.9764404296875, 40.763901280945866],[ -73.94622802734375, 40.686886382151116],[ -73.9544677734375, 40.61186744303007]],
+          [[-74.1851806640625,40.81588791441588],[-74.00665283203124,40.83251504043271],[-73.948974609375,40.7909394098518],[-73.8006591796875,40.751418432997426],[-73.4326171875,40.79301881008675]]
+        ]
+      }
+      @route = create(:route, geometry: geojson)
+      create(:route_serving_stop, route_id: @route.id, stop_id: stop.id)
+      @bbox1 = [-121.0,34.0,-123.0,36.0]
+      @bbox2 = [-125.0,34.0,-123.0,36.0]
+      @bbox3 = [-73.87481689453125,40.88860081193033,-73.94622802734375,40.686886382151116]
+    end
+
+    it 'has a stop within bbox' do
+      expect(Route.where_stop_within_bbox(@bbox1)).to match_array([@route])
+      expect(Route.where_stop_within_bbox(@bbox2)).to match_array([])
+      expect(Route.where_stop_within_bbox(@bbox3)).to match_array([])
+    end
+
+    it 'has geometry within bbox' do
+      expect(Route.within_bbox(@bbox1)).to match_array([])
+      expect(Route.within_bbox(@bbox2)).to match_array([])
+      expect(Route.within_bbox(@bbox3)).to match_array([@route])
+    end
   end
+
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -52,6 +52,22 @@ describe Route do
   end
 
   it 'can be found when has stop within bbox query' do
-    
+    point = Stop::GEOFACTORY.point(-122.0, 35.0)
+    stop = create(:stop, geometry: point.to_s)
+    geojson = {
+      type: 'MultiLineString',
+      coordinates: [
+        [[-73.87481689453125, 40.88860081193033],[ -73.9764404296875, 40.763901280945866],[ -73.94622802734375, 40.686886382151116],[ -73.9544677734375, 40.61186744303007]],
+        [[-74.1851806640625,40.81588791441588],[-74.00665283203124,40.83251504043271],[-73.948974609375,40.7909394098518],[-73.8006591796875,40.751418432997426],[-73.4326171875,40.79301881008675]]
+      ]
+    }
+    route = create(:route, geometry: geojson)
+    rsp = create(:route_serving_stop, route_id: route.id, stop_id: stop.id)
+    bbox1 = [-121.0,34.0,-123.0,36.0]
+    bbox2 = [-125.0,34.0,-123.0,36.0]
+    bbox3 = [-73.87481689453125,40.88860081193033,-73.94622802734375,40.686886382151116]
+    expect(Route.where_stop_within_bbox(bbox1)).to match_array([route])
+    expect(Route.where_stop_within_bbox(bbox2)).to match_array([])
+    expect(Route.where_stop_within_bbox(bbox3)).to match_array([])
   end
 end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -70,9 +70,9 @@ describe Route do
     end
 
     it 'has a stop within bbox' do
-      expect(Route.where_stop_within_bbox(@bbox_should_contain_stop_not_geom)).to match_array([@route])
-      expect(Route.where_stop_within_bbox(@bbox_should_neither_contain_stop_nor_geom)).to match_array([])
-      expect(Route.where_stop_within_bbox(@bbox_should_contain_geom_only)).to match_array([])
+      expect(Route.stop_within_bbox(@bbox_should_contain_stop_not_geom)).to match_array([@route])
+      expect(Route.stop_within_bbox(@bbox_should_neither_contain_stop_nor_geom)).to match_array([])
+      expect(Route.stop_within_bbox(@bbox_should_contain_geom_only)).to match_array([])
     end
 
     it 'has geometry within bbox' do

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -63,22 +63,22 @@ describe Route do
         ]
       }
       @route = create(:route, geometry: geojson)
-      create(:route_serving_stop, route_id: @route.id, stop_id: stop.id)
-      @bbox1 = [-121.0,34.0,-123.0,36.0]
-      @bbox2 = [-125.0,34.0,-123.0,36.0]
-      @bbox3 = [-73.87481689453125,40.88860081193033,-73.94622802734375,40.686886382151116]
+      create(:route_serving_stop, route: @route, stop: stop)
+      @bbox_should_contain_stop_not_geom = [-121.0,34.0,-123.0,36.0]
+      @bbox_should_neither_contain_stop_nor_geom = [-125.0,34.0,-123.0,36.0]
+      @bbox_should_contain_geom_only = [-73.87481689453125,40.88860081193033,-73.94622802734375,40.686886382151116]
     end
 
     it 'has a stop within bbox' do
-      expect(Route.where_stop_within_bbox(@bbox1)).to match_array([@route])
-      expect(Route.where_stop_within_bbox(@bbox2)).to match_array([])
-      expect(Route.where_stop_within_bbox(@bbox3)).to match_array([])
+      expect(Route.where_stop_within_bbox(@bbox_should_contain_stop_not_geom)).to match_array([@route])
+      expect(Route.where_stop_within_bbox(@bbox_should_neither_contain_stop_nor_geom)).to match_array([])
+      expect(Route.where_stop_within_bbox(@bbox_should_contain_geom_only)).to match_array([])
     end
 
     it 'has geometry within bbox' do
-      expect(Route.within_bbox(@bbox1)).to match_array([])
-      expect(Route.within_bbox(@bbox2)).to match_array([])
-      expect(Route.within_bbox(@bbox3)).to match_array([@route])
+      expect(Route.within_bbox(@bbox_should_contain_stop_not_geom)).to match_array([])
+      expect(Route.within_bbox(@bbox_should_neither_contain_stop_nor_geom)).to match_array([])
+      expect(Route.within_bbox(@bbox_should_contain_geom_only)).to match_array([@route])
     end
   end
 

--- a/spec/models/stop_spec.rb
+++ b/spec/models/stop_spec.rb
@@ -88,14 +88,14 @@ describe Stop do
       santa_clara = create(:stop, geometry: { type: 'Point', coordinates: [-121.936376, 37.352915] })
       mountain_view = create(:stop, geometry: { type: 'Point', coordinates: [-122.076327, 37.393879] })
       random = create(:stop, geometry: { type: 'Point', coordinates: [10.195312, 43.755225] })
-      expect(Stop.within_bbox('-122.0,37.25,-121.75,37.5')).to match_array([santa_clara])
-      expect(Stop.within_bbox('-122.25,37.25,-122.0,37.5')).to match_array([mountain_view])
+      expect(Stop.geometry_within_bbox('-122.0,37.25,-121.75,37.5')).to match_array([santa_clara])
+      expect(Stop.geometry_within_bbox('-122.25,37.25,-122.0,37.5')).to match_array([mountain_view])
     end
 
     it 'fails gracefully when ill-formed bounding box is provided' do
-      expect { Stop.within_bbox('-122.25,37.25,-122.0') }.to raise_error(ArgumentError)
-      expect { Stop.within_bbox() }.to raise_error(ArgumentError)
-      expect { Stop.within_bbox([-122.25,37.25,-122.0]) }.to raise_error(ArgumentError)
+      expect { Stop.geometry_within_bbox('-122.25,37.25,-122.0') }.to raise_error(ArgumentError)
+      expect { Stop.geometry_within_bbox() }.to raise_error(ArgumentError)
+      expect { Stop.geometry_within_bbox([-122.25,37.25,-122.0]) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
Updating Api::V1::RoutesController to return routes serving stops within the bbox query instead of routes having geometries within the bbox. Added scope Route.where_stop_within_bbox to retrieve the routes for the Controller. Added tests for Route and RouteController.