### PR TITLE
Stop conflation logger

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -240,7 +240,7 @@ class Stop < BaseStop
           way_id = tyr_locate_response[index][:edges][0][:way_id]
           stop_tags = stop.tags.try(:clone) || {}
           if stop_tags[:osm_way_id] != way_id
-            logger.info "OSM Way Id changed for stop #{stop.id}: was #{stop_tags[:osm_way_id]} now #{way_id}"
+            logger.info "osm_way_id changed for Stop #{stop.id}: was \"#{stop_tags[:osm_way_id]}\" now \"#{way_id}\""
           end
           stop_tags[:osm_way_id] = way_id
           stop.update(tags: stop_tags)

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -240,7 +240,7 @@ class Stop < BaseStop
           way_id = tyr_locate_response[index][:edges][0][:way_id]
           stop_tags = stop.tags.try(:clone) || {}
           if stop_tags[:osm_way_id] != way_id
-            logger.info "osm_way_id changed for Stop #{stop.id}: was \"#{stop_tags[:osm_way_id]}\" now \"#{way_id}\""
+            logger.info "osm_way_id changed for Stop #{stop.onestop_id}: was \"#{stop_tags[:osm_way_id]}\" now \"#{way_id}\""
           end
           stop_tags[:osm_way_id] = way_id
           stop.update(tags: stop_tags)

--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -239,6 +239,9 @@ class Stop < BaseStop
         group.each_with_index do |stop, index|
           way_id = tyr_locate_response[index][:edges][0][:way_id]
           stop_tags = stop.tags.try(:clone) || {}
+          if stop_tags[:osm_way_id] != way_id
+            logger.info "OSM Way Id changed for stop #{stop.id}: was #{stop_tags[:osm_way_id]} now #{way_id}"
+          end
           stop_tags[:osm_way_id] = way_id
           stop.update(tags: stop_tags)
           stop.update(last_conflated_at: now)


### PR DESCRIPTION
When a Stop osm_way_id is changed via Stop.conflate_with_osm, the change is logged within the “info” category.