### PR TITLE
reducing Sidekiq concurrency on prod

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 staging:
   :concurrency: 5
 production:
-  :concurrency: 20
+  :concurrency: 10
 :limits:
   feed_eater: 1
 :process_limits:


### PR DESCRIPTION
to reduce the chance of overloading database with connections during FeedEater/FeedEaterSchedule jobs