### PR TITLE
Use OJ for JSON serialization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'rack-cors', require: 'rack/cors'
 # providing API
 gem 'active_model_serializers', '0.9.3'
 gem 'oj'
+gem 'oj_mimic_json'
 
 # consuming other APIs
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     oj (2.14.1)
+    oj_mimic_json (1.0.1)
     pg (0.18.4)
     pghero (1.1.4)
       activerecord
@@ -382,6 +383,7 @@ DEPENDENCIES
   marginalia
   mock_redis
   oj
+  oj_mimic_json
   pg
   pghero
   pry-byebug

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,7 @@
+# Oj: a fast JSON parser and Object marshaller as a Ruby gem
+# https://github.com/ohler55/oj#options
+
+Oj.default_options = {
+  bigdecimal_load: :auto,
+  float_precision: 0 # use Ruby
+}


### PR DESCRIPTION
The [OJ gem](https://github.com/ohler55/oj) ("Optimized Json") is faster than Ruby's built-in JSON serializer. I thought by including the gem it would be automatically used by ActiveModelSerializers. Apparently not.

Including `oj_mimic_json` now makes sure to use OJ for JSON serialization. Should lead to some slight performance improvements when rendering a bunch of JSON on API endpoints.