### PR TITLE
fix for: FeedVersion attachment temp files are lingering on worker servers

### DIFF
--- a/app/uploaders/feed_version_uploader.rb
+++ b/app/uploaders/feed_version_uploader.rb
@@ -29,8 +29,8 @@ class FeedVersionUploader < CarrierWave::Uploader::Base
   end
 
   def remove_any_local_cached_copies
-    if (cache_id = cached?)
-      FileUtils.rm_rf(File.join(root, cache_dir, cache_id))
+    if cached?
+      FileUtils.rm_rf(File.dirname(path))
     end
   end
 end


### PR DESCRIPTION
fixes #264