### PR TITLE
add vehicle_type index to Route tables

### DIFF
--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -17,12 +17,13 @@
 #
 # Indexes
 #
-#  c_route_cu_in_changeset              (created_or_updated_in_changeset_id)
-#  index_current_routes_on_geometry     (geometry)
-#  index_current_routes_on_identifiers  (identifiers)
-#  index_current_routes_on_operator_id  (operator_id)
-#  index_current_routes_on_tags         (tags)
-#  index_current_routes_on_updated_at   (updated_at)
+#  c_route_cu_in_changeset               (created_or_updated_in_changeset_id)
+#  index_current_routes_on_geometry      (geometry)
+#  index_current_routes_on_identifiers   (identifiers)
+#  index_current_routes_on_operator_id   (operator_id)
+#  index_current_routes_on_tags          (tags)
+#  index_current_routes_on_updated_at    (updated_at)
+#  index_current_routes_on_vehicle_type  (vehicle_type)
 #
 
 class BaseRoute < ActiveRecord::Base

--- a/app/serializers/route_serializer.rb
+++ b/app/serializers/route_serializer.rb
@@ -17,12 +17,13 @@
 #
 # Indexes
 #
-#  c_route_cu_in_changeset              (created_or_updated_in_changeset_id)
-#  index_current_routes_on_geometry     (geometry)
-#  index_current_routes_on_identifiers  (identifiers)
-#  index_current_routes_on_operator_id  (operator_id)
-#  index_current_routes_on_tags         (tags)
-#  index_current_routes_on_updated_at   (updated_at)
+#  c_route_cu_in_changeset               (created_or_updated_in_changeset_id)
+#  index_current_routes_on_geometry      (geometry)
+#  index_current_routes_on_identifiers   (identifiers)
+#  index_current_routes_on_operator_id   (operator_id)
+#  index_current_routes_on_tags          (tags)
+#  index_current_routes_on_updated_at    (updated_at)
+#  index_current_routes_on_vehicle_type  (vehicle_type)
 #
 
 class RouteSerializer < CurrentEntitySerializer

--- a/db/migrate/20151223172515_add_vehicle_type_index_to_routes.rb
+++ b/db/migrate/20151223172515_add_vehicle_type_index_to_routes.rb
@@ -1,0 +1,7 @@
+class AddVehicleTypeIndexToRoutes < ActiveRecord::Migration
+  def change
+    [:current, :old].each do |version|
+      add_index "#{version}_routes", :vehicle_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151222213427) do
+ActiveRecord::Schema.define(version: 20151223172515) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 20151222213427) do
   add_index "current_routes", ["operator_id"], name: "index_current_routes_on_operator_id", using: :btree
   add_index "current_routes", ["tags"], name: "index_current_routes_on_tags", using: :btree
   add_index "current_routes", ["updated_at"], name: "index_current_routes_on_updated_at", using: :btree
+  add_index "current_routes", ["vehicle_type"], name: "index_current_routes_on_vehicle_type", using: :btree
 
   create_table "current_routes_serving_stop", force: :cascade do |t|
     t.integer  "route_id"
@@ -395,6 +396,7 @@ ActiveRecord::Schema.define(version: 20151222213427) do
   add_index "old_routes", ["geometry"], name: "index_old_routes_on_geometry", using: :gist
   add_index "old_routes", ["identifiers"], name: "index_old_routes_on_identifiers", using: :gin
   add_index "old_routes", ["operator_type", "operator_id"], name: "index_old_routes_on_operator_type_and_operator_id", using: :btree
+  add_index "old_routes", ["vehicle_type"], name: "index_old_routes_on_vehicle_type", using: :btree
 
   create_table "old_routes_serving_stop", force: :cascade do |t|
     t.integer  "route_id"

--- a/spec/factories/route_factory.rb
+++ b/spec/factories/route_factory.rb
@@ -17,12 +17,13 @@
 #
 # Indexes
 #
-#  c_route_cu_in_changeset              (created_or_updated_in_changeset_id)
-#  index_current_routes_on_geometry     (geometry)
-#  index_current_routes_on_identifiers  (identifiers)
-#  index_current_routes_on_operator_id  (operator_id)
-#  index_current_routes_on_tags         (tags)
-#  index_current_routes_on_updated_at   (updated_at)
+#  c_route_cu_in_changeset               (created_or_updated_in_changeset_id)
+#  index_current_routes_on_geometry      (geometry)
+#  index_current_routes_on_identifiers   (identifiers)
+#  index_current_routes_on_operator_id   (operator_id)
+#  index_current_routes_on_tags          (tags)
+#  index_current_routes_on_updated_at    (updated_at)
+#  index_current_routes_on_vehicle_type  (vehicle_type)
 #
 
 FactoryGirl.define do

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -17,12 +17,13 @@
 #
 # Indexes
 #
-#  c_route_cu_in_changeset              (created_or_updated_in_changeset_id)
-#  index_current_routes_on_geometry     (geometry)
-#  index_current_routes_on_identifiers  (identifiers)
-#  index_current_routes_on_operator_id  (operator_id)
-#  index_current_routes_on_tags         (tags)
-#  index_current_routes_on_updated_at   (updated_at)
+#  c_route_cu_in_changeset               (created_or_updated_in_changeset_id)
+#  index_current_routes_on_geometry      (geometry)
+#  index_current_routes_on_identifiers   (identifiers)
+#  index_current_routes_on_operator_id   (operator_id)
+#  index_current_routes_on_tags          (tags)
+#  index_current_routes_on_updated_at    (updated_at)
+#  index_current_routes_on_vehicle_type  (vehicle_type)
 #
 
 describe Route do


### PR DESCRIPTION
should have been on #267 because the Route API endpoint allows filtering by `vehicle_type`

closes #268