### PR TITLE
reduce staging log level

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.force_ssl = true
 
   # Set to :debug to see everything in the log.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Enable the logstasher logs for the current environment
   config.logstasher.enabled = true


### PR DESCRIPTION
Dev servers are filling up with too much--probably all the insert and commit statements that are generated by `FeedEaterScheduleWorker` jobs.