### PR TITLE
fix for: operator re-imported from multiple feed versions lists duplicate `imported_from_feed_onestop_ids`

### DIFF
--- a/app/serializers/entity_serializer.rb
+++ b/app/serializers/entity_serializer.rb
@@ -4,10 +4,10 @@ class EntitySerializer < ApplicationSerializer
              :imported_from_feed_version_sha1s
 
   def imported_from_feed_onestop_ids
-    object.imported_from_feeds.map(&:onestop_id)
+    object.imported_from_feeds.pluck(:onestop_id).uniq
   end
 
   def imported_from_feed_version_sha1s
-    object.imported_from_feed_versions.map(&:sha1)
+    object.imported_from_feed_versions.pluck(:sha1).uniq
   end
 end


### PR DESCRIPTION
fixes #302