### PR TITLE
Add find_by_onestop_ids, find_by_onestop_ids! methods

### DIFF
--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -104,11 +104,11 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
     end
     # Service between stops
     if params[:origin_onestop_id].present?
-      origin_stops = Stop.where(onestop_id: params[:origin_onestop_id].split(','))
+      origin_stops = Stop.find_by_onestop_ids!(params[:origin_onestop_id].split(','))
       @ssps = @ssps.where(origin: origin_stops)
     end
     if params[:destination_onestop_id].present?
-      destination_stops = Stop.where(onestop_id: params[:destination_onestop_id].split(','))
+      destination_stops = Stop.find_by_onestop_ids!(params[:destination_onestop_id].split(','))
       @ssps = @ssps.where(destination: destination_stops)
     end
     # Departing between...
@@ -122,11 +122,11 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
     end
     # Service on a route
     if params[:route_onestop_id].present?
-      routes = Route.where(onestop_id: params[:route_onestop_id].split(','))
+      routes = Route.find_by_onestop_ids!(params[:route_onestop_id].split(','))
       @ssps = @ssps.where(route: routes)
     end
     if params[:operator_onestop_id].present?
-      operators = Operator.where(onestop_id: params[:operator_onestop_id].split(','))
+      operators = Operator.find_by_onestop_ids!(params[:operator_onestop_id].split(','))
       @ssps = @ssps.where(operator: operators)
     end
     # Stops in a bounding box

--- a/app/models/concerns/has_a_onestop_id.rb
+++ b/app/models/concerns/has_a_onestop_id.rb
@@ -16,10 +16,11 @@ module HasAOnestopId
     end
 
     def self.find_by_onestop_ids!(onestop_ids)
-      results = self.where(onestop_id: onestop_ids).all
-      missing = onestop_ids - results.map(&:onestop_id)
+      # First query to check for missing id's
+      missing = onestop_ids - self.where(onestop_id: onestop_ids).pluck(:onestop_id)
       fail ActiveRecord::RecordNotFound, "Couldn't find: #{missing.join(' ')}" if missing.size > 0
-      results
+      # Second query as usual
+      self.where(onestop_id: onestop_ids)
     end
 
     def self.find_by_onestop_ids(onestop_ids)

--- a/app/models/concerns/has_a_onestop_id.rb
+++ b/app/models/concerns/has_a_onestop_id.rb
@@ -14,6 +14,18 @@ module HasAOnestopId
       # TODO: make this case insensitive
       self.find_by(onestop_id: onestop_id)
     end
+
+    def self.find_by_onestop_ids!(onestop_ids)
+      results = self.where(onestop_id: onestop_ids).all
+      missing = onestop_ids - results.map(&:onestop_id)
+      fail ActiveRecord::RecordNotFound, "Couldn't find: #{missing.join(' ')}" if missing.size > 0
+      results
+    end
+
+    def self.find_by_onestop_ids(onestop_ids)
+      self.where(onestop_id: onestop_ids)
+    end
+
   end
 
   private

--- a/spec/models/concerns/has_a_onestop_id_spec.rb
+++ b/spec/models/concerns/has_a_onestop_id_spec.rb
@@ -1,4 +1,28 @@
 describe HasAOnestopId do
+  context 'find_by_onestop_ids' do
+    let(:stop1) { create(:stop) }
+    let(:stop2) { create(:stop) }
+    it 'returns all matches' do
+      expect(Stop.find_by_onestop_ids([stop1.onestop_id, stop2.onestop_id])).to eq([stop1, stop2])
+    end
+
+    it 'filters out missing' do
+      expect(Stop.find_by_onestop_ids([stop1.onestop_id, 's-9q9-missing'])).to eq([stop1])
+    end
+  end
+
+  context 'find_by_onestop_ids!' do
+    let(:stop1) { create(:stop) }
+    let(:stop2) { create(:stop) }
+    it 'returns all matches' do
+      expect(Stop.find_by_onestop_ids!([stop1.onestop_id, stop2.onestop_id])).to eq([stop1, stop2])
+    end
+
+    it 'raises exception on missing' do
+      expect { Stop.find_by_onestop_ids!(['s-9q9-missing']) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
   context 'validation' do
     it 'for a Stop, must start with "s-" as its 1st component' do
       stop = Stop.new(onestop_id: '9q9-asd')


### PR DESCRIPTION
Allow easier detection of missing records when multiple are specified,
e.g. SSP API.

Resolves #330