### PR TITLE
SSP where_service_before_date

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Example URL  | Parameters
 `GET /api/v1/schedule_stop_pairs?destination_onestop_id=s-9q8yyugptw-sanfranciscocaltrainstation` | Find all Schedule Stop Pairs to a destination. Accepts multiple Onestop IDs, separated by commas.
 `GET /api/v1/schedule_stop_pairs?date=2015-08-05` | Find all Schedule Stop Pairs from origin on date
 `GET /api/v1/schedule_stop_pairs?service_from_date=2015-08-05` | Find all Schedule Stop Pairs in effect from a date
+`GET /api/v1/schedule_stop_pairs?service_before_date=2015-10-20` | Find all Schedule Stop Pairs in effect before a date
 `GET /api/v1/schedule_stop_pairs?origin_departure_between=09:00:00,09:10:00` | Find all Schedule Stop Pairs with origin_departure_time in a range
 `GET /api/v1/schedule_stop_pairs?trip=6507768-CT-14OCT-Combo-Weekday-01` | Find all Schedule Stop Pairs by trip identifier
 `GET /api/v1/schedule_stop_pairs?route_onestop_id=r-9q8y-richmond~dalycity~millbrae` | Find all Schedule Stop Pairs by route. Accepts multiple Onestop IDs, separated by commas.

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -74,6 +74,7 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
           params.slice(
             :date,
             :service_from_date,
+            :service_before_date,
             :origin_onestop_id,
             :destination_onestop_id,
             :origin_departure_between,
@@ -101,6 +102,9 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
     end
     if params[:service_from_date].present?
       @ssps = @ssps.where_service_from_date(params[:service_from_date])
+    end
+    if params[:service_before_date].present?
+      @ssps = @ssps.where_service_before_date(params[:service_before_date])
     end
     # Service between stops
     if params[:origin_onestop_id].present?

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -128,6 +128,11 @@ class ScheduleStopPair < BaseScheduleStopPair
     where("service_end_date >= ?", date)
   }
 
+  scope :where_service_before_date, -> (date) {
+    date = date.is_a?(Date) ? date : Date.parse(date)
+    where("service_start_date <= ?", date)
+  }
+  
   # Service trips_out in a bbox
   scope :where_origin_bbox, -> (bbox) {
     stops = Stop.geometry_within_bbox(bbox)

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -28,6 +28,7 @@ if LogStasher.enabled?
       :r,
       :route_onestop_id,
       :service_from_date,
+      :service_before_date,
       :tag_key,
       :tag_value,
       :trip,

--- a/doc/schedule_api.md
+++ b/doc/schedule_api.md
@@ -63,6 +63,7 @@ The main ScheduleStopPair API endpoint is [/api/v1/schedule_stop_pairs](http://t
 | operator_onestop_id      | Onestop ID | Operator. Accepts multiple separated by commas. | [on BART](http://transit.land/api/v1/schedule_stop_pairs?operator_onestop_id=o-9q9-bart) |
 | service_date             | Date | Service operates on a date | [valid on 2015-10-26](http://transit.land/api/v1/schedule_stop_pairs?date=2015-10-26) |
 | service_from_date        | Date | Service operates on a date, or in the future | [valid on and after 2015-10-26](http://transit.land/api/v1/schedule_stop_pairs?service_from_date=2015-10-26) |
+| service_before_date      | Date | Service operates up to and including date | [valid on and before 2015-11-30](http://transit.land/api/v1/schedule_stop_pairs?service_before_date=2015-11-30) |
 | origin_departure_between | Time,Time | Origin departure time between two times | [departing between 07:00 - 09:00](http://transit.land/api/v1/schedule_stop_pairs?origin_departure_between=07:00:00,09:00:00) |
 | trip                     | String | Trip identifier | [on trip '03SFO11SUN'](http://transit.land/api/v1/schedule_stop_pairs?trip=03SFO11SUN) |
 | bbox                     | Lon1,Lat1,Lon2,Lat2 | Origin Stop within bounding box | [in the Bay Area](http://transit.land/api/v1/schedule_stop_pairs?bbox=-123.057,36.701,-121.044,38.138)

--- a/spec/models/schedule_stop_pair_spec.rb
+++ b/spec/models/schedule_stop_pair_spec.rb
@@ -175,6 +175,45 @@ RSpec.describe ScheduleStopPair, type: :model do
       expect(ScheduleStopPair.where_service_from_date(expect_end2).count).to eq(0)
     end
 
+    it 'where service before date' do
+      expect_none = Date.new(2010, 01, 01)
+      expect_all = Date.new(2020, 01, 01)
+      expect_start1 = Date.new(2013, 01, 01)
+      expect_start2 = Date.new(2015, 01, 01)
+      expect_end1 = Date.new(2016, 01, 01)
+      expect_end2 = Date.new(2018, 01, 01)
+      create(:schedule_stop_pair, service_start_date: expect_start1, service_end_date: expect_end1)
+      create(:schedule_stop_pair, service_start_date: expect_start2, service_end_date: expect_end2)
+      expect(ScheduleStopPair.where_service_before_date(expect_none).count).to eq(0)
+      expect(ScheduleStopPair.where_service_before_date(expect_all).count).to eq(2)
+      expect(ScheduleStopPair.where_service_before_date(expect_start1).count).to eq(1)
+      expect(ScheduleStopPair.where_service_before_date(expect_start2).count).to eq(2)
+    end
+
+    it 'where service before and after dates' do
+      # test where_service_before_date & where_service_from_date together
+      expect_start1 = Date.new(2013, 01, 01)
+      expect_start2 = Date.new(2015, 01, 01)
+      expect_end1 = Date.new(2016, 01, 01)
+      expect_end2 = Date.new(2018, 01, 01)
+      create(:schedule_stop_pair, service_start_date: expect_start1, service_end_date: expect_end1)
+      create(:schedule_stop_pair, service_start_date: expect_start2, service_end_date: expect_end2)
+      tests = [
+        ['2010-01-01', '2020-01-01', 2],
+        ['2010-01-01', '2013-01-01', 1],
+        ['2010-01-01', '2014-01-01', 1],
+        ['2010-01-01', '2015-01-01', 2],
+        ['2020-01-01', '2022-01-01', 0],
+      ].each do |start_date, end_date, count|
+        expect(
+          ScheduleStopPair
+            .where_service_from_date(start_date)
+            .where_service_before_date(end_date)
+            .count
+        ).to eq(count)
+      end
+    end
+
     it 'where origin_departure_between' do
       create(:schedule_stop_pair, origin_departure_time: '09:00:00')
       create(:schedule_stop_pair, origin_departure_time: '09:05:00')


### PR DESCRIPTION
Add query option to find services that have not yet begun. 

This can be combined with service_from_date to query an SSP 'window', with edges only relevant for a bounded date range.

Resolves #309