### PR TITLE
Handle EntitiesImportedFromFeed relations in Changeset apply

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -131,7 +131,7 @@ class Changeset < ActiveRecord::Base
   end
 
   def apply!
-    fail raise Changeset::Error.new(self, 'has already been applied.') if applied
+    fail Changeset::Error.new(self, 'has already been applied.') if applied
     Changeset.transaction do
       begin
         change_payloads.each do |change_payload|

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -83,6 +83,8 @@ class Changeset < ActiveRecord::Base
       stops_created_or_updated +
       operators_created_or_updated +
       routes_created_or_updated +
+      route_stop_patterns_created_or_updated +
+      schedule_stop_pairs_created_or_updated +
       operators_serving_stop_created_or_updated +
       routes_serving_stop_created_or_updated
     )
@@ -94,7 +96,9 @@ class Changeset < ActiveRecord::Base
       operators_in_feed_created_or_updated +
       stops_created_or_updated +
       operators_created_or_updated +
-      routes_created_or_updated
+      routes_created_or_updated +
+      route_stop_patterns_created_or_updated +
+      schedule_stop_pairs_created_or_updated
     )
   end
 

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -82,9 +82,9 @@ class Changeset < ActiveRecord::Base
       operators_in_feed_created_or_updated +
       stops_created_or_updated +
       operators_created_or_updated +
-      routes_created_or_updated # +
-      # operators_serving_stop_created_or_updated +
-      # routes_serving_stop_created_or_updated
+      routes_created_or_updated +
+      operators_serving_stop_created_or_updated +
+      routes_serving_stop_created_or_updated
     )
   end
 

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -74,44 +74,35 @@ class Changeset < ActiveRecord::Base
   after_initialize :set_default_values
   after_create :creation_email
 
-  def entities_created_or_updated
-    # NOTE: this is probably evaluating the SQL queries, rather than merging together ARel relations
-    # in Rails 5, there will be an ActiveRecord::Relation.or() operator to use instead here
-    (
-      feeds_created_or_updated +
-      operators_in_feed_created_or_updated +
-      stops_created_or_updated +
-      operators_created_or_updated +
-      routes_created_or_updated +
-      route_stop_patterns_created_or_updated +
-      schedule_stop_pairs_created_or_updated
-    )
+  def entities_created_or_updated(&block)
+    # Pass &block to find_each for each kind of entity.
+    feeds_created_or_updated.find_each(&block)
+    operators_in_feed_created_or_updated.find_each(&block)
+    stops_created_or_updated.find_each(&block)
+    operators_created_or_updated.find_each(&block)
+    routes_created_or_updated.find_each(&block)
+    route_stop_patterns_created_or_updated.find_each(&block)
+    schedule_stop_pairs_created_or_updated.find_each(&block)
   end
 
-  def relations_created_or_updated
-    (
-      operators_serving_stop_created_or_updated +
-      routes_serving_stop_created_or_updated
-    )
+  def relations_created_or_updated(&block)
+    operators_serving_stop_created_or_updated.find_each(&block)
+    routes_serving_stop_created_or_updated.find_each(&block)
   end
 
-  def entities_destroyed
-    (
-      feeds_destroyed +
-      operators_in_feed_destroyed +
-      stops_destroyed +
-      operators_destroyed +
-      routes_destroyed +
-      route_stop_patterns_destroyed +
-      schedule_stop_pairs_destroyed
-    )
+  def entities_destroyed(&block)
+    feeds_destroyed.find_each(&block)
+    operators_destroyed.find_each(&block)
+    stops_destroyed.find_each(&block)
+    operators_destroyed.find_each(&block)
+    routes_destroyed.find_each(&block)
+    route_stop_patterns_destroyed.find_each(&block)
+    schedule_stop_pairs_destroyed.find_each(&block)
   end
 
-  def relations_destroyed
-    (
-      operators_serving_stop_destroyed +
-      routes_serving_stop_destroyed
-    )
+  def relations_destroyed(&block)
+    operators_serving_stop_destroyed.find_each(&block)
+    routes_serving_stop_destroyed.find_each(&block)
   end
 
   def trial_succeeds?
@@ -140,7 +131,7 @@ class Changeset < ActiveRecord::Base
         self.update(applied: true, applied_at: Time.now)
         # Create any feed-entity associations
         if feed && feed_version
-          self.entities_created_or_updated.each do |entity|
+          self.entities_created_or_updated do |entity|
             entity
               .entities_imported_from_feed
               .find_or_initialize_by(feed: feed, feed_version: feed_version)

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -62,6 +62,8 @@ class Changeset < ActiveRecord::Base
   has_many :route_stop_patterns_destroyed, class_name: 'OldRouteStopPattern', foreign_key: 'destroyed_in_changeset_id'
 
   belongs_to :user, autosave: true
+  belongs_to :feed
+  belongs_to :feed_version
 
   def set_user_by_params(user_params)
     self.user = User.find_or_initialize_by(email: user_params[:email])

--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -84,21 +84,14 @@ class Changeset < ActiveRecord::Base
       operators_created_or_updated +
       routes_created_or_updated +
       route_stop_patterns_created_or_updated +
-      schedule_stop_pairs_created_or_updated +
-      operators_serving_stop_created_or_updated +
-      routes_serving_stop_created_or_updated
+      schedule_stop_pairs_created_or_updated
     )
   end
 
-  def onestop_entities_created_or_updated
+  def relations_created_or_updated
     (
-      feeds_created_or_updated +
-      operators_in_feed_created_or_updated +
-      stops_created_or_updated +
-      operators_created_or_updated +
-      routes_created_or_updated +
-      route_stop_patterns_created_or_updated +
-      schedule_stop_pairs_created_or_updated
+      operators_serving_stop_created_or_updated +
+      routes_serving_stop_created_or_updated
     )
   end
 
@@ -109,6 +102,13 @@ class Changeset < ActiveRecord::Base
       stops_destroyed +
       operators_destroyed +
       routes_destroyed +
+      route_stop_patterns_destroyed +
+      schedule_stop_pairs_destroyed
+    )
+  end
+
+  def relations_destroyed
+    (
       operators_serving_stop_destroyed +
       routes_serving_stop_destroyed
     )
@@ -139,13 +139,13 @@ class Changeset < ActiveRecord::Base
         end
         self.update(applied: true, applied_at: Time.now)
         # Create any feed-entity associations
-        if self.feed
-          self.onestop_entities_created_or_updated.each { |e|
-            e
+        if feed && feed_version
+          self.entities_created_or_updated.each do |entity|
+            entity
               .entities_imported_from_feed
               .find_or_initialize_by(feed: feed, feed_version: feed_version)
               .save!
-          }
+          end
         end
         # Destroy change payloads
         change_payloads.destroy_all

--- a/app/models/concerns/is_an_entity_imported_from_feeds.rb
+++ b/app/models/concerns/is_an_entity_imported_from_feeds.rb
@@ -1,18 +1,8 @@
 module IsAnEntityImportedFromFeeds
   extend ActiveSupport::Concern
-
   included do
     has_many :entities_imported_from_feed, as: :entity
     has_many :imported_from_feeds, through: :entities_imported_from_feed, source: :feed
     has_many :imported_from_feed_versions, through: :entities_imported_from_feed, source: :feed_version
-  end
-
-  def imported_from_feed=(imported_from_feed_params)
-    params = HashHelpers::update_keys(imported_from_feed_params, :underscore)
-    feed = params[:feed] || Feed.find_by!(onestop_id: params[:onestop_id])
-    if params[:sha1].present?
-      feed_version = params[:feed_version] || feed.feed_versions.find_by!(sha1: params[:sha1])
-    end
-    self.entities_imported_from_feed.find_or_initialize_by(feed: feed, feed_version: feed_version)
   end
 end

--- a/app/models/json_schemas/operator.json
+++ b/app/models/json_schemas/operator.json
@@ -46,19 +46,6 @@
         "format": "stop-onestop-id"
       }
     },
-    "importedFromFeed": {
-      "type": "object",
-      "properties": {
-        "onestopId": {
-          "type": "string",
-          "format": "feed-onestop-id"
-        },
-        "sha1": {
-          "type": "string",
-          "format": "sha1"
-        }
-      }
-    },
     "website": {
       "type": "string"
     }

--- a/app/models/json_schemas/route.json
+++ b/app/models/json_schemas/route.json
@@ -47,19 +47,6 @@
         "type": "string",
         "format": "stop-onestop-id"
       }
-    },
-    "importedFromFeed": {
-      "type": "object",
-      "properties": {
-        "onestopId": {
-          "type": "string",
-          "format": "feed-onestop-id"
-        },
-        "sha1": {
-          "type": "string",
-          "format": "sha1"
-        }
-      }
     }
   }
 }

--- a/app/models/json_schemas/route_stop_pattern.json
+++ b/app/models/json_schemas/route_stop_pattern.json
@@ -41,19 +41,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "importedFromFeed": {
-      "type": "object",
-      "properties": {
-        "onestopId": {
-          "type": "string",
-          "format": "feed-onestop-id"
-        },
-        "sha1": {
-          "type": "string",
-          "format": "sha1"
-        }
-      }
     }
   }
 }

--- a/app/models/json_schemas/schedule_stop_pair.json
+++ b/app/models/json_schemas/schedule_stop_pair.json
@@ -6,7 +6,6 @@
     "originOnestopId",
     "destinationOnestopId",
     "routeOnestopId",
-    "importedFromFeed",
     "originArrivalTime",
     "originDepartureTime",
     "destinationArrivalTime",
@@ -91,19 +90,6 @@
     "pickupType": { "type": ["string","null"] },
     "dropOffType": { "type": ["string","null"] },
     "shapeDistTraveled": { "type": ["number","null"] },
-    "tags": { "type": "object" },
-    "importedFromFeed": {
-      "type": "object",
-      "properties": {
-        "onestopId": {
-          "type": "string",
-          "format": "feed-onestop-id"
-        },
-        "sha1": {
-          "type": "string",
-          "format": "sha1"
-        }
-      }
-    }
+    "tags": { "type": "object" }
   }
 }

--- a/app/models/json_schemas/stop.json
+++ b/app/models/json_schemas/stop.json
@@ -40,19 +40,6 @@
         "type": "string",
         "format": "operator-onestop-id"
       }
-    },
-    "importedFromFeed": {
-      "type": "object",
-      "properties": {
-        "onestopId": {
-          "type": "string",
-          "format": "feed-onestop-id"
-        },
-        "sha1": {
-          "type": "string",
-          "format": "sha1"
-        }
-      }
     }
   }
 }

--- a/app/serializers/changeset_serializer.rb
+++ b/app/serializers/changeset_serializer.rb
@@ -23,15 +23,24 @@ class ChangesetSerializer < ApplicationSerializer
              :created_at,
              :updated_at,
              :change_payloads,
-             :user
+             :user,
+             :feed_onestop_id,
+             :feed_version_sha1
 
   def user
     object.user.id if object.user
   end
 
-
   def change_payloads
     object.change_payloads.pluck(:id)
+  end
+
+  def feed_onestop_id
+    object.feed.try(:onestop_id)
+  end
+
+  def feed_version_sha1
+    object.feed_version.try(:sha1)
   end
 
 end

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -346,10 +346,6 @@ class GTFSGraph
       onestopId: entity.onestop_id,
       name: entity.name,
       identifiedBy: entity.identified_by.uniq,
-      importedFromFeed: {
-        onestopId: @feed.onestop_id,
-        sha1: @feed_version.sha1
-      },
       geometry: entity.geometry,
       tags: entity.tags || {},
       timezone: entity.timezone,
@@ -362,10 +358,6 @@ class GTFSGraph
       onestopId: entity.onestop_id,
       name: entity.name,
       identifiedBy: entity.identified_by.uniq,
-      importedFromFeed: {
-        onestopId: @feed.onestop_id,
-        sha1: @feed_version.sha1
-      },
       geometry: entity.geometry,
       tags: entity.tags || {},
       timezone: entity.timezone
@@ -377,10 +369,6 @@ class GTFSGraph
       onestopId: entity.onestop_id,
       name: entity.name,
       identifiedBy: entity.identified_by.uniq,
-      importedFromFeed: {
-        onestopId: @feed.onestop_id,
-        sha1: @feed_version.sha1
-      },
       operatedBy: entity.operator.onestop_id,
       vehicleType: entity.vehicle_type,
       serves: entity.serves.map(&:onestop_id),
@@ -409,10 +397,6 @@ class GTFSGraph
     {
       onestopId: entity.onestop_id,
       identifiedBy: entity.identified_by.uniq,
-      importedFromFeed: {
-        onestopId: @feed.onestop_id,
-        sha1: @feed_version.sha1
-      },
       stopPattern: entity.stop_pattern,
       geometry: entity.geometry,
       isGenerated: entity.is_generated,
@@ -425,10 +409,6 @@ class GTFSGraph
 
   def make_change_ssp(entity)
     {
-      importedFromFeed: {
-        onestopId: @feed.onestop_id,
-        sha1: @feed_version.sha1
-      },
       originOnestopId: entity.origin.onestop_id,
       originTimezone: entity.origin_timezone,
       originArrivalTime: entity.origin_arrival_time,

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -30,7 +30,7 @@ class GTFSGraph
     stops = routes.map { |route| route.serves }.reduce(Set.new, :+)
     rsps = routes.map { |route| route.route_stop_patterns }.reduce(Set.new, :+)
     log "Create changeset"
-    changeset = Changeset.create()
+    changeset = Changeset.create(feed: @feed, feed_version: @feed_version)
     log "Create: Operators, Stops, Routes"
     # Update Feed Bounding Box
     log "  updating feed bounding box"
@@ -78,7 +78,7 @@ class GTFSGraph
       rsp_distances_map[onestop_id] = distances
     end
     log "Create changeset"
-    changeset = Changeset.create()
+    changeset = Changeset.create(feed: @feed, feed_version: @feed_version)
     log "Create: SSPs"
     total = 0
     ssps = []

--- a/db/migrate/20160130014111_add_feed_version_to_changeset.rb
+++ b/db/migrate/20160130014111_add_feed_version_to_changeset.rb
@@ -1,0 +1,6 @@
+class AddFeedVersionToChangeset < ActiveRecord::Migration
+  def change
+    add_reference :changesets, :feed, index: true
+    add_reference :changesets, :feed_version, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160128305523) do
+ActiveRecord::Schema.define(version: 20160130014111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,8 +34,12 @@ ActiveRecord::Schema.define(version: 20160128305523) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
+    t.integer  "feed_id"
+    t.integer  "feed_version_id"
   end
 
+  add_index "changesets", ["feed_id"], name: "index_changesets_on_feed_id", using: :btree
+  add_index "changesets", ["feed_version_id"], name: "index_changesets_on_feed_version_id", using: :btree
   add_index "changesets", ["user_id"], name: "index_changesets_on_user_id", using: :btree
 
   create_table "current_feeds", force: :cascade do |t|

--- a/spec/models/operator_serving_stop_spec.rb
+++ b/spec/models/operator_serving_stop_spec.rb
@@ -52,11 +52,13 @@ describe OperatorServingStop do
       @changeset1.apply!
       expect(Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway').operators).to include Operator.find_by_onestop_id!('o-9q8y-SFMTA')
       expect(Operator.find_by_onestop_id!('o-9q8y-SFMTA').stops).to include Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway')
-      expect(@changeset1.entities_created_or_updated).to match_array([
-        Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway'),
+      expect(@changeset1.stops_created_or_updated).to match_array([
+        Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway')
+      ])
+      expect(@changeset1.operators_created_or_updated).to match_array([
         Operator.find_by_onestop_id!('o-9q8y-SFMTA')
       ])
-      expect(@changeset1.relations_created_or_updated).to match_array([
+      expect(@changeset1.operators_serving_stop_created_or_updated).to match_array([
         OperatorServingStop.find_by_attributes({ operator_onestop_id: 'o-9q8y-SFMTA', stop_onestop_id: 's-9q8yt4b-19Hollway'})
       ])
     end

--- a/spec/models/operator_serving_stop_spec.rb
+++ b/spec/models/operator_serving_stop_spec.rb
@@ -54,7 +54,9 @@ describe OperatorServingStop do
       expect(Operator.find_by_onestop_id!('o-9q8y-SFMTA').stops).to include Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway')
       expect(@changeset1.entities_created_or_updated).to match_array([
         Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway'),
-        Operator.find_by_onestop_id!('o-9q8y-SFMTA'),
+        Operator.find_by_onestop_id!('o-9q8y-SFMTA')
+      ])
+      expect(@changeset1.relations_created_or_updated).to match_array([
         OperatorServingStop.find_by_attributes({ operator_onestop_id: 'o-9q8y-SFMTA', stop_onestop_id: 's-9q8yt4b-19Hollway'})
       ])
     end

--- a/spec/models/operator_spec.rb
+++ b/spec/models/operator_spec.rb
@@ -44,30 +44,4 @@ describe Operator do
     expect(Operator.with_identifier_or_name('SFMTA')).to match_array([sfmta])
   end
 
-  it 'IsAnEntityImportedFromFeeds imported_from_feed_onestop_id' do
-    feed = create(:feed)
-    bart = build(:operator, name: 'BART', identifiers: ['Bay Area Rapid Transit'])
-    bart.imported_from_feed = { onestopId: feed.onestop_id }
-    bart.save!
-    expect(bart.imported_from_feeds).to match_array([feed])
-  end
-
-  it 'IsAnEntityImportedFromFeeds imported_from_feed_onestop_id requires valid feed onestop_id' do
-    bart = build(:operator, name: 'BART', identifiers: ['Bay Area Rapid Transit'])
-    expect {
-      bart.imported_from_feed = { onestopId: 'f-9q9-unknown' }
-    }.to raise_error(ActiveRecord::RecordNotFound)
-  end
-
-  it 'IsAnEntityImportedFromFeeds imported_from_feed_onestop_id no duplicates' do
-    feed = create(:feed)
-    bart = build(:operator, name: 'BART', identifiers: ['Bay Area Rapid Transit'])
-    bart.imported_from_feed = { onestopId: feed.onestop_id }
-    bart.save!
-    expect(bart.imported_from_feeds).to match_array([feed])
-    bart.imported_from_feed = { onestopId: feed.onestop_id }
-    bart.save!
-    expect(bart.imported_from_feeds).to match_array([feed])
-  end
-
 end

--- a/spec/models/route_serving_stop_spec.rb
+++ b/spec/models/route_serving_stop_spec.rb
@@ -66,13 +66,13 @@ describe RouteServingStop do
       @changeset1.apply!
       expect(Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway').operators).to include Operator.find_by_onestop_id!('o-9q8y-SFMTA')
       expect(Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway').routes).to include Route.find_by_onestop_id!('r-9q8y-19Express')
-      expect(@changeset1.entities_created_or_updated).to match_array([
-        Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway'),
-        Operator.find_by_onestop_id!('o-9q8y-SFMTA'),
-        Route.find_by_onestop_id!('r-9q8y-19Express')
+      expect(@changeset1.stops_created_or_updated).to match_array([Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway')])
+      expect(@changeset1.operators_created_or_updated).to match_array([Operator.find_by_onestop_id!('o-9q8y-SFMTA')])
+      expect(@changeset1.routes_created_or_updated).to match_array([Route.find_by_onestop_id!('r-9q8y-19Express')])
+      expect(@changeset1.operators_serving_stop_created_or_updated).to match_array([
+        OperatorServingStop.find_by_attributes({ operator_onestop_id: 'o-9q8y-SFMTA', stop_onestop_id: 's-9q8yt4b-19Hollway'})
       ])
-      expect(@changeset1.relations_created_or_updated).to match_array([
-        OperatorServingStop.find_by_attributes({ operator_onestop_id: 'o-9q8y-SFMTA', stop_onestop_id: 's-9q8yt4b-19Hollway'}),
+      expect(@changeset1.routes_serving_stop_created_or_updated).to match_array([
         RouteServingStop.find_by_attributes({ route_onestop_id: 'r-9q8y-19Express', stop_onestop_id: 's-9q8yt4b-19Hollway'})
       ])
       expect(Route.find_by_onestop_id!('r-9q8y-19Express').geometry[:coordinates][0][0]).to eq [-73.87481689453125, 40.88860081193033]

--- a/spec/models/route_serving_stop_spec.rb
+++ b/spec/models/route_serving_stop_spec.rb
@@ -69,7 +69,9 @@ describe RouteServingStop do
       expect(@changeset1.entities_created_or_updated).to match_array([
         Stop.find_by_onestop_id!('s-9q8yt4b-19Hollway'),
         Operator.find_by_onestop_id!('o-9q8y-SFMTA'),
-        Route.find_by_onestop_id!('r-9q8y-19Express'),
+        Route.find_by_onestop_id!('r-9q8y-19Express')
+      ])
+      expect(@changeset1.relations_created_or_updated).to match_array([
         OperatorServingStop.find_by_attributes({ operator_onestop_id: 'o-9q8y-SFMTA', stop_onestop_id: 's-9q8yt4b-19Hollway'}),
         RouteServingStop.find_by_attributes({ route_onestop_id: 'r-9q8y-19Express', stop_onestop_id: 's-9q8yt4b-19Hollway'})
       ])

--- a/spec/services/operator_route_stop_relationship_spec.rb
+++ b/spec/services/operator_route_stop_relationship_spec.rb
@@ -14,7 +14,7 @@ describe OperatorRouteStopRelationship do
     it 'should be able to create an OperatorServingStop when none exists already' do
       @operator_route_stop_relationship1.apply_change(in_changeset: @changeset1)
       expect(@stop.operators).to include @operator
-      expect(@changeset1.relations_created_or_updated).to include OperatorServingStop.first
+      expect(@changeset1.operators_serving_stop_created_or_updated).to include OperatorServingStop.first
     end
 
     it 'should be able to delete an OperatorServingStop when one already exists' do
@@ -30,7 +30,6 @@ describe OperatorRouteStopRelationship do
       expect(@stop.operators).to_not include @operator
       expect(OldOperatorServingStop.count).to eq 1
       expect(changeset2.operators_serving_stop_destroyed).to include OldOperatorServingStop.first
-      expect(changeset2.relations_destroyed).to include OldOperatorServingStop.first
     end
 
     it "should be agreeable when trying to delete an OperatorServingStop that doesn't exist" do

--- a/spec/services/operator_route_stop_relationship_spec.rb
+++ b/spec/services/operator_route_stop_relationship_spec.rb
@@ -14,7 +14,7 @@ describe OperatorRouteStopRelationship do
     it 'should be able to create an OperatorServingStop when none exists already' do
       @operator_route_stop_relationship1.apply_change(in_changeset: @changeset1)
       expect(@stop.operators).to include @operator
-      expect(@changeset1.entities_created_or_updated).to include OperatorServingStop.first
+      expect(@changeset1.relations_created_or_updated).to include OperatorServingStop.first
     end
 
     it 'should be able to delete an OperatorServingStop when one already exists' do
@@ -30,7 +30,7 @@ describe OperatorRouteStopRelationship do
       expect(@stop.operators).to_not include @operator
       expect(OldOperatorServingStop.count).to eq 1
       expect(changeset2.operators_serving_stop_destroyed).to include OldOperatorServingStop.first
-      expect(changeset2.entities_destroyed).to include OldOperatorServingStop.first
+      expect(changeset2.relations_destroyed).to include OldOperatorServingStop.first
     end
 
     it "should be agreeable when trying to delete an OperatorServingStop that doesn't exist" do


### PR DESCRIPTION
Currently, all EntitiesImportedFromFeed (EIFF) records are handled by including 'importedFromFeed' in each Change. However, this results in a more complicated Changeset process, and limits opportunities for streamlining and performance improvements (bulk imports).

This PR restructures this process. Each Changeset can now be associated with a Feed & FeedVersion, and when applied, creates associations between the Feed, FeedVersion, and each updated Entity (Stop, Route, etc.) in that Changeset. This results in simpler, more consistent behavior, and will be easier to maintain and optimize in the future.

Please note the changes to Changeset#entities_created_or_updated. It is now split into two methods, one for Entities (Stop, Route, Feed, Operator, SSP, RSP), and a second Changeset#relations_created_or_updated for relations (OperatorServingStop, RouteServingStop). Also note the methods no longer return a concatenated array of results, but accept a block that is passed to the find_each for each association.

Resolves #338 