### PR TITLE
Fix missing operator in feed

### DIFF
--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -1,5 +1,8 @@
 class GTFSGraph
 
+  class Error < StandardError
+  end
+
   CHANGE_PAYLOAD_MAX_ENTITIES = Figaro.env.feed_eater_change_payload_max_entities.try(:to_i) || 1_000
   STOP_TIMES_MAX_LOAD = Figaro.env.feed_eater_stop_times_max_load.try(:to_i) || 100_000
 
@@ -26,6 +29,7 @@ class GTFSGraph
     load_tl_routes
     load_tl_route_stop_patterns
     operators = load_tl_operators
+    fail GTFSGraph::Error.new('No agencies found that match operators_in_feed') unless operators.size > 0
     routes = operators.map { |operator| operator.serves }.reduce(Set.new, :+)
     stops = routes.map { |route| route.serves }.reduce(Set.new, :+)
     rsps = routes.map { |route| route.route_stop_patterns }.reduce(Set.new, :+)

--- a/spec/services/gtfs_graph_spec.rb
+++ b/spec/services/gtfs_graph_spec.rb
@@ -13,6 +13,17 @@ end
 
 describe GTFSGraph do
 
+  context 'load operators' do
+    it 'fails if no matching operator_in_feed' do
+      feed_version = create(:feed_version_caltrain)
+      feed = feed_version.feed
+      oif = feed.operators_in_feed.first
+      oif.update!({gtfs_agency_id:'not-found'})
+      graph = GTFSGraph.new(feed_version.file.path, feed, feed_version)
+      expect { graph.create_change_osr(1) }.to raise_error(GTFSGraph::Error)
+    end
+  end
+
   context 'can apply level 0 and 1 changesets' do
     before(:each) { @feed, @feed_version = load_feed(1) }
 


### PR DESCRIPTION
Feeds maintain a mapping between Operator onestop_id <-> agency_id in the GTFS feed. This PR resolves an issue where a feed without any matching agency_id's could partially import, then fail mysteriously. The failure is now explicit, with a GTFSGraph::Error exception.

Resolves #356 