### PR TITLE
Fix#355

### DIFF
--- a/db/migrate/20160203195950_change_column_identifiers_in_route_stop_patterns.rb
+++ b/db/migrate/20160203195950_change_column_identifiers_in_route_stop_patterns.rb
@@ -1,0 +1,8 @@
+class ChangeColumnIdentifiersInRouteStopPatterns < ActiveRecord::Migration
+  def change
+    ["current","old"].each do |version|
+      remove_column "#{version}_route_stop_patterns", :identifiers, array: true, index: true, default: []
+      add_column "#{version}_route_stop_patterns", :identifiers, :string, array: true, index: true, default: [], using: :gin
+    end
+  end
+end

--- a/db/migrate/20160203195950_change_column_identifiers_in_route_stop_patterns.rb
+++ b/db/migrate/20160203195950_change_column_identifiers_in_route_stop_patterns.rb
@@ -1,8 +1,0 @@
-class ChangeColumnIdentifiersInRouteStopPatterns < ActiveRecord::Migration
-  def change
-    ["current","old"].each do |version|
-      remove_column "#{version}_route_stop_patterns", :identifiers, array: true, index: true, default: []
-      add_column "#{version}_route_stop_patterns", :identifiers, :string, array: true, index: true, default: [], using: :gin
-    end
-  end
-end

--- a/db/migrate/20160204180147_change_column_identifiers_index_in_route_stop_patterns.rb
+++ b/db/migrate/20160204180147_change_column_identifiers_index_in_route_stop_patterns.rb
@@ -1,0 +1,8 @@
+class ChangeColumnIdentifiersIndexInRouteStopPatterns < ActiveRecord::Migration
+  def change
+    ["current","old"].each do |version|
+      remove_index "#{version}_route_stop_patterns", :identifiers
+      add_index "#{version}_route_stop_patterns", :identifiers, using: :gin
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160203195950) do
+ActiveRecord::Schema.define(version: 20160204180147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,14 +131,15 @@ ActiveRecord::Schema.define(version: 20160203195950) do
     t.boolean   "is_generated",                                                                                   default: false
     t.boolean   "is_modified",                                                                                    default: false
     t.string    "trips",                                                                                          default: [],                 array: true
+    t.string    "identifiers",                                                                                    default: [],                 array: true
     t.datetime  "created_at",                                                                                                     null: false
     t.datetime  "updated_at",                                                                                                     null: false
     t.integer   "created_or_updated_in_changeset_id"
     t.integer   "route_id"
-    t.string    "identifiers",                                                                                    default: [],                 array: true
   end
 
   add_index "current_route_stop_patterns", ["created_or_updated_in_changeset_id"], name: "c_rsp_cu_in_changeset", using: :btree
+  add_index "current_route_stop_patterns", ["identifiers"], name: "index_current_route_stop_patterns_on_identifiers", using: :gin
   add_index "current_route_stop_patterns", ["onestop_id"], name: "index_current_route_stop_patterns_on_onestop_id", using: :btree
   add_index "current_route_stop_patterns", ["route_id"], name: "index_current_route_stop_patterns_on_route_id", using: :btree
   add_index "current_route_stop_patterns", ["stop_pattern"], name: "index_current_route_stop_patterns_on_stop_pattern", using: :btree
@@ -415,16 +416,17 @@ ActiveRecord::Schema.define(version: 20160203195950) do
     t.boolean   "is_generated",                                                                                   default: false
     t.boolean   "is_modified",                                                                                    default: false
     t.string    "trips",                                                                                          default: [],                 array: true
+    t.string    "identifiers",                                                                                    default: [],                 array: true
     t.datetime  "created_at",                                                                                                     null: false
     t.datetime  "updated_at",                                                                                                     null: false
     t.integer   "created_or_updated_in_changeset_id"
     t.integer   "destroyed_in_changeset_id"
     t.integer   "route_id"
     t.string    "route_type"
-    t.string    "identifiers",                                                                                    default: [],                 array: true
   end
 
   add_index "old_route_stop_patterns", ["created_or_updated_in_changeset_id"], name: "o_rsp_cu_in_changeset", using: :btree
+  add_index "old_route_stop_patterns", ["identifiers"], name: "index_old_route_stop_patterns_on_identifiers", using: :gin
   add_index "old_route_stop_patterns", ["onestop_id"], name: "index_old_route_stop_patterns_on_onestop_id", using: :btree
   add_index "old_route_stop_patterns", ["route_type", "route_id"], name: "index_old_route_stop_patterns_on_route_type_and_route_id", using: :btree
   add_index "old_route_stop_patterns", ["stop_pattern"], name: "index_old_route_stop_patterns_on_stop_pattern", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160130014111) do
+ActiveRecord::Schema.define(version: 20160203195950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,15 +131,14 @@ ActiveRecord::Schema.define(version: 20160130014111) do
     t.boolean   "is_generated",                                                                                   default: false
     t.boolean   "is_modified",                                                                                    default: false
     t.string    "trips",                                                                                          default: [],                 array: true
-    t.string    "identifiers",                                                                                    default: [],                 array: true
     t.datetime  "created_at",                                                                                                     null: false
     t.datetime  "updated_at",                                                                                                     null: false
     t.integer   "created_or_updated_in_changeset_id"
     t.integer   "route_id"
+    t.string    "identifiers",                                                                                    default: [],                 array: true
   end
 
   add_index "current_route_stop_patterns", ["created_or_updated_in_changeset_id"], name: "c_rsp_cu_in_changeset", using: :btree
-  add_index "current_route_stop_patterns", ["identifiers"], name: "index_current_route_stop_patterns_on_identifiers", using: :btree
   add_index "current_route_stop_patterns", ["onestop_id"], name: "index_current_route_stop_patterns_on_onestop_id", using: :btree
   add_index "current_route_stop_patterns", ["route_id"], name: "index_current_route_stop_patterns_on_route_id", using: :btree
   add_index "current_route_stop_patterns", ["stop_pattern"], name: "index_current_route_stop_patterns_on_stop_pattern", using: :btree
@@ -416,17 +415,16 @@ ActiveRecord::Schema.define(version: 20160130014111) do
     t.boolean   "is_generated",                                                                                   default: false
     t.boolean   "is_modified",                                                                                    default: false
     t.string    "trips",                                                                                          default: [],                 array: true
-    t.string    "identifiers",                                                                                    default: [],                 array: true
     t.datetime  "created_at",                                                                                                     null: false
     t.datetime  "updated_at",                                                                                                     null: false
     t.integer   "created_or_updated_in_changeset_id"
     t.integer   "destroyed_in_changeset_id"
     t.integer   "route_id"
     t.string    "route_type"
+    t.string    "identifiers",                                                                                    default: [],                 array: true
   end
 
   add_index "old_route_stop_patterns", ["created_or_updated_in_changeset_id"], name: "o_rsp_cu_in_changeset", using: :btree
-  add_index "old_route_stop_patterns", ["identifiers"], name: "index_old_route_stop_patterns_on_identifiers", using: :btree
   add_index "old_route_stop_patterns", ["onestop_id"], name: "index_old_route_stop_patterns_on_onestop_id", using: :btree
   add_index "old_route_stop_patterns", ["route_type", "route_id"], name: "index_old_route_stop_patterns_on_route_type_and_route_id", using: :btree
   add_index "old_route_stop_patterns", ["stop_pattern"], name: "index_old_route_stop_patterns_on_stop_pattern", using: :btree


### PR DESCRIPTION
closes #355. changing the index type for RouteStopPattern column identifiers from btree to gin.