### PR TITLE
Fix case where Feed.operators_in_feed gtfs_agency_id is nil

### DIFF
--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -182,8 +182,10 @@ class GTFSGraph
     # Operators
     log "  operators"
     operators = Set.new
+    # key=nil is poorly defined in gtfs wrapper
+    agencies = Hash[@gtfs.agencies.map { |a| [a.id,a] }]
     @feed.operators_in_feed.each do |oif|
-      entity = @gtfs.agency(oif.gtfs_agency_id)
+      entity = agencies[oif.gtfs_agency_id]
       # Skip Operator if not found
       next unless entity
       # Find: (child gtfs routes) to (tl routes)


### PR DESCRIPTION
The GTFS wrapper doesn't handle nil entity id's very well. This workaround simply creates a new hash directly from the GTFS agencies, skipping the internal cache that is normally used by gtfs.agency(id).

Resolves #374 