### PR TITLE
Preserve ChangePayloads by default

### DIFF
--- a/app/models/changeset.rb
+++ b/app/models/changeset.rb
@@ -121,6 +121,11 @@ class Changeset < ActiveRecord::Base
     trial_succeeds
   end
 
+  def destroy_all_change_payloads
+    # Destroy change payloads
+    change_payloads.destroy_all
+  end
+
   def apply!
     fail Changeset::Error.new(self, 'has already been applied.') if applied
     Changeset.transaction do
@@ -138,8 +143,6 @@ class Changeset < ActiveRecord::Base
               .save!
           end
         end
-        # Destroy change payloads
-        change_payloads.destroy_all
       rescue
         logger.error "Error applying Changeset #{self.id}: #{$!.message}"
         logger.error $!.backtrace

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -59,6 +59,7 @@ class GTFSGraph
     log "Changeset apply"
     t = Time.now
     changeset.apply!
+    changeset.destroy_all_change_payloads
     log "  apply done: time #{Time.now - t}"
   end
 
@@ -122,6 +123,7 @@ class GTFSGraph
     log "Changeset apply"
     t = Time.now
     changeset.apply!
+    changeset.destroy_all_change_payloads
     log "  apply done: total time: #{Time.now - t}"
   end
 

--- a/spec/models/changeset_spec.rb
+++ b/spec/models/changeset_spec.rb
@@ -170,15 +170,6 @@ describe Changeset do
       expect(Stop.find_by_onestop_id('s-9q8yt4b-1AvHoS')).to be_nil
     end
 
-    it 'deletes payloads after applying' do
-      payload_ids = @changeset1.change_payload_ids
-      expect(payload_ids.length).to eq 1
-      @changeset1.apply!
-      payload_ids.each do |i|
-        expect(ChangePayload.find_by(id: i)).to be_nil
-      end
-    end
-
     it 'to create and remove a relationship' do
       @changeset1.apply!
       @changeset2.apply!
@@ -240,6 +231,18 @@ describe Changeset do
 
   context 'revert' do
     pending 'write some specs'
+  end
+
+  context '#destroy_all_change_payloads' do
+    it 'destroys all ChangePayloads' do
+      changeset = create(:changeset_with_payload)
+      payload_ids = changeset.change_payload_ids
+      expect(payload_ids.length).to eq 1
+      changeset.destroy_all_change_payloads
+      payload_ids.each do |i|
+        expect(ChangePayload.find_by(id: i)).to be_nil
+      end
+    end
   end
 
   it 'will conflate stops with OSM after the DB transaction is complete' do


### PR DESCRIPTION
Don't automatically destroy ChangePayloads during Changeset.apply.

However, destroy ChangePayloads after a Feed import job.

Resolves #370 