### PR TITLE
update error messages

### DIFF
--- a/app/workers/feed_info_worker.rb
+++ b/app/workers/feed_info_worker.rb
@@ -16,23 +16,23 @@ class FeedInfoWorker
     rescue GTFS::InvalidSourceException => e
       errors << {
         exception: 'InvalidSourceException',
-        message: 'Invalid GTFS Feed'
+        message: 'This file does not appear to be a valid GTFS feed. Contact Transitland for more help.'
       }
     rescue SocketError => e
       errors << {
         exception: 'SocketError',
-        message: 'Error connecting to host'
+        message: 'There was a problem downloading the file. Check the address and try again, or contact the transit operator for more help.'
       }
     rescue Net::HTTPServerException => e
       errors << {
         exception: 'HTTPServerException',
-        message: e.to_s,
+        message: "There was an error downloading the file. The transit operator server responded with: #{e.to_s}.",
         response_code: e.response.code
       }
     rescue StandardError => e
       errors << {
         exception: e.class.name,
-        message: 'Could not download file'
+        message: 'There was a problem downloading or processing from this URL.'
       }
     else
       response[:feed] = FeedSerializer.new(feed).as_json

--- a/spec/workers/feed_info_worker_spec.rb
+++ b/spec/workers/feed_info_worker_spec.rb
@@ -24,7 +24,7 @@ describe FeedInfoWorker do
     cachedata = Rails.cache.read(cachekey)
     expect(cachedata[:status]).to eq('error')
     expect(cachedata[:errors].first[:exception]).to eq('HTTPServerException')
-    expect(cachedata[:errors].first[:message]).to eq('404 "Not Found"')
+    expect(cachedata[:errors].first[:message]).to eq('There was an error downloading the file. The transit operator server responded with: 404 "Not Found".')
     expect(cachedata[:errors].first[:response_code]).to eq('404')
   end
 
@@ -50,6 +50,6 @@ describe FeedInfoWorker do
     cachedata = Rails.cache.read(cachekey)
     expect(cachedata[:status]).to eq('error')
     expect(cachedata[:errors].first[:exception]).to eq('InvalidSourceException')
-    expect(cachedata[:errors].first[:message]).to eq('Invalid GTFS Feed')
+    expect(cachedata[:errors].first[:message]).to eq('This file does not appear to be a valid GTFS feed. Contact Transitland for more help.')
   end
 end


### PR DESCRIPTION
closes https://github.com/transitland/feed-registry/issues/216

closes https://github.com/transitland/feed-registry/issues/211

This PR updates the Feed Registry error messages.