### PR TITLE
FeedFetch HTTPS

### DIFF
--- a/spec/services/feed_fetch_spec.rb
+++ b/spec/services/feed_fetch_spec.rb
@@ -4,6 +4,7 @@ describe FeedFetch do
   let (:url_redirect_many) { 'http://httpbin.org/absolute-redirect/6' }
   let (:url_404) { 'http://httpbin.org/status/404' }
   let (:url_binary) { 'http://httpbin.org/stream-bytes/1024?seed=0' }
+  let (:url_ssl) { 'https://httpbin.org/get'}
 
   context '.fetch' do
     it 'returns a response' do
@@ -20,6 +21,15 @@ describe FeedFetch do
         FeedFetch.fetch(url_redirect) { |resp| response = JSON.parse(resp.read_body) }
         expect(response['url']).to eq(url)
       end
+    end
+
+    it 'follows SSL' do
+      VCR.use_cassette('feed_fetch_ssl') do
+        response = {}
+        FeedFetch.fetch(url_ssl) { |resp| response = JSON.parse(resp.read_body) }
+        expect(response['url']).to eq(url_ssl)
+      end
+
     end
 
     it 'follows a redirect no more than limit times' do

--- a/spec/support/vcr_cassettes/feed_fetch_ssl.yml
+++ b/spec/support/vcr_cassettes/feed_fetch_ssl.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://httpbin.org/get
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 16 Feb 2016 21:59:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '248'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n
+        \   \"Accept-Encoding\": \"gzip;q=1.0,deflate;q=0.6,identity;q=0.3\", \n    \"Host\":
+        \"httpbin.org\", \n    \"User-Agent\": \"Ruby\"\n  }, \n  \"origin\": \"172.125.87.109\",
+        \n  \"url\": \"https://httpbin.org/get\"\n}\n"
+    http_version: 
+  recorded_at: Tue, 16 Feb 2016 21:59:29 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Correctly get HTTPS urls, including redirect-to-ssl.

Fixes #407 