### PR TITLE
Fix FeedFetch: Operator has no stops

### DIFF
--- a/app/services/feed_info.rb
+++ b/app/services/feed_info.rb
@@ -49,6 +49,8 @@ class FeedInfo
     # operators
     operators = []
     @gtfs.agencies.each do |agency|
+      visited_stops = agency_visited_stops[agency] || []
+      next if visited_stops.size == 0
       operator = Operator.from_gtfs(agency, agency_visited_stops[agency])
       operators << operator
       feed.operators_in_feed.new(gtfs_agency_id: agency.id, operator: operator, id: nil)

--- a/app/workers/feed_eater_worker.rb
+++ b/app/workers/feed_eater_worker.rb
@@ -81,6 +81,7 @@ end
 
 if __FILE__ == $0
   require 'sidekiq/testing'
+  Sidekiq::Testing.inline!
   ActiveRecord::Base.logger = Logger.new(STDOUT)
   feed_onestop_id = ARGV[0] || 'f-9q9-caltrain'
   import_level = (ARGV[1].presence || 1).to_i


### PR DESCRIPTION
FeedFetch Info failed when an operator had no associated stops.

Resolves https://github.com/transitland/transitland/issues/19