### PR TITLE
SSP controller default scope and new query params

### DIFF
--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -96,14 +96,24 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
   private
 
   def set_schedule_stop_pairs
-    # FeedVersion Import level
     @ssps = ScheduleStopPair.where('')
-    if params[:import_level].present?
-      @ssps = @ssps.where_import_level(params[:import_level])
+    # Feed Version, or default: All active Feed Versions
+    if params[:feed_version_sha1]
+      @ssps = @ssps.where(feed_version: FeedVersion.find_by(sha1: params[:feed_version_sha1]))
+    else
+      @ssps = @ssps.where_active
     end
-    # FeedVersion Active
+    # Explicitly use active Feed Versions
     if params[:active].presence == 'true'
       @ssps = @ssps.where_active
+    end
+    # Feed
+    if params[:feed_onestop_id]
+      @ssps = @ssps.where(feed: Feed.find_by_onestop_id!(params[:feed_onestop_id]))
+    end
+    # FeedVersion Import level
+    if params[:import_level].present?
+      @ssps = @ssps.where_import_level(params[:import_level])
     end
     # Service on a date
     if params[:date].present?

--- a/doc/schedule_api.md
+++ b/doc/schedule_api.md
@@ -9,6 +9,8 @@ Transitland models each trip between two stops as an edge, called a `ScheduleSto
 | route_onestop_id             | Onestop ID | Route |
 | operator_onestop_id          | Onestop ID | Operator |
 | origin_onestop_id            | Onestop ID | Origin stop |
+| feed_onestop_id              | Onestop ID | Feed |
+| feed_version_sha1            | String | Feed Version |
 | origin_timezone              | String | Origin stop timezone |
 | origin_arrival_time          | Time | Time vehicle arrives at origin from previous stop |
 | origin_departure_time        | Time | Time vehicle leaves origin |
@@ -35,6 +37,10 @@ Transitland models each trip between two stops as an edge, called a `ScheduleSto
 | pickup_type                  | Enum | Passenger pickup |
 | active                       | Boolean | SSPs from active FeedVersions |
 | import_level                 | Integer | SSPs from FeedVersion with import_level |
+
+### Active vs. inactive Feed Versions
+
+Each Feed may only have a single active Feed Version at a time, generally the most recent version fetched and imported. By default, only SSPs for active Feed Versions are returned. However, a specific Feed Version can be explicitly specified using feed_version_sha1, returning only SSPs for that Feed Version, even if it is not the currently active version.
 
 ### Data types
 

--- a/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
+++ b/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
@@ -1,0 +1,38 @@
+describe Api::V1::ScheduleStopPairsController do
+
+  before(:each) do
+    @feed = create(:feed)
+    @feed_version1 = create(:feed_version, feed: @feed)
+    @ssp1 = create(:schedule_stop_pair, feed: @feed_version1.feed, feed_version: @feed_version1)
+    @feed.update(active_feed_version: @feed_version1)
+    @feed_version2 = create(:feed_version, feed: @feed)
+    @ssp2 = create(:schedule_stop_pair, feed: @feed_version2.feed, feed_version: @feed_version2)
+  end
+
+  describe 'GET index' do
+    context 'default' do
+      it 'where_active default scope' do
+        get :index
+        expect(JSON.parse(response.body)["schedule_stop_pairs"].size).to eq(1)
+      end
+    end
+
+    context 'feed_onestop_id' do
+      it 'filters by feed_onestop_id' do
+
+      end
+    end
+
+    context 'feed_version_sha1' do
+      it 'filters by feed_version_sha1' do
+
+      end
+
+      it 'overrides default where_active scope' do
+
+      end
+    end
+  end
+
+
+end

--- a/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
+++ b/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
@@ -1,38 +1,96 @@
 describe Api::V1::ScheduleStopPairsController do
 
   before(:each) do
+    # Create feeds
     @feed = create(:feed)
-    @feed_version1 = create(:feed_version, feed: @feed)
-    @ssp1 = create(:schedule_stop_pair, feed: @feed_version1.feed, feed_version: @feed_version1)
-    @feed.update(active_feed_version: @feed_version1)
-    @feed_version2 = create(:feed_version, feed: @feed)
-    @ssp2 = create(:schedule_stop_pair, feed: @feed_version2.feed, feed_version: @feed_version2)
+    @feed_version_inactive = create(:feed_version, feed: @feed, import_level: 2)
+    @feed_version_active = create(:feed_version, feed: @feed, import_level: 3)
+    @feed.update(active_feed_version: @feed_version_active)
+    # 1 inactive, 2 active
+    @ssps = []
+    @ssps << create(:schedule_stop_pair, feed: @feed_version_inactive.feed, feed_version: @feed_version_inactive)
+    @ssps << create(:schedule_stop_pair, feed: @feed_version_active.feed, feed_version: @feed_version_active)
+    @ssps << create(:schedule_stop_pair, feed: @feed_version_active.feed, feed_version: @feed_version_active)
   end
 
   describe 'GET index' do
     context 'default' do
       it 'where_active default scope' do
         get :index
-        expect(JSON.parse(response.body)["schedule_stop_pairs"].size).to eq(1)
+        expect_json_sizes(schedule_stop_pairs: 2)
       end
     end
 
     context 'feed_onestop_id' do
-      it 'filters by feed_onestop_id' do
-
+      it 'filters by feed_onestop_id and active' do
+        get :index, feed_onestop_id: @feed.onestop_id
+        expect_json_sizes(schedule_stop_pairs: 2)
       end
     end
 
     context 'feed_version_sha1' do
       it 'filters by feed_version_sha1' do
-
+        get :index, feed_version_sha1: @feed_version_active.sha1
+        expect_json_sizes(schedule_stop_pairs: 2)
       end
 
       it 'overrides default where_active scope' do
-
+        get :index, feed_version_sha1: @feed_version_inactive.sha1
+        expect_json_sizes(schedule_stop_pairs: 1)
       end
     end
+
+    context 'where_active' do
+      it 'explicitly sets where_active' do
+        get :index, active: 'true', feed_version_sha1: @feed_version_inactive.sha1
+        expect_json_sizes(schedule_stop_pairs: 0)
+      end
+    end
+
+    context 'import_level' do
+      it 'filters by import_level' do
+        get :index, import_level: 3
+        expect_json_sizes(schedule_stop_pairs: 2)
+      end
+    end
+
+    context 'date' do
+    end
+
+    context 'service_from_date' do
+    end
+
+    context 'service_before_date' do
+    end
+
+    context 'origin_onestop_id' do
+    end
+
+    context 'destination_onestop_id' do
+    end
+
+    context 'origin_departure_between' do
+    end
+
+    context 'trip' do
+    end
+
+    context 'route_onestop_id' do
+    end
+
+    context 'route_stop_pattern_onestop_id' do
+    end
+
+    context 'operator_onestop_id' do
+    end
+
+    context 'bbox' do
+    end
+
+    context 'updated_since' do
+    end
+
+    context 'included' do
+    end
   end
-
-
 end


### PR DESCRIPTION
The SSP controller default scope is now `where_active`.

New query parameters:
 - feed_onestop_id
 - feed_version_sha1 (overrides where_active)

Resolves #427