### PR TITLE
Improved Feed Version activation & SSP cleanup

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -173,8 +173,6 @@ class Feed < BaseFeed
   def activate_feed_version(feed_version_sha1)
     self.transaction do
       feed_version = self.feed_versions.find_by!(sha1: feed_version_sha1)
-      raise Exception.new('Cannot activate already active feed') if feed_version == self.active_feed_version
-      self.active_feed_version.delete_schedule_stop_pairs! if self.active_feed_version
       self.update!(active_feed_version: feed_version)
     end
   end

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -18,6 +18,11 @@ class GTFSGraph
     @onestop_id_to_entity = {}
   end
 
+  def cleanup
+    log "Cleanup any existing FeedVersion SSPs"
+    @feed_version.delete_schedule_stop_pairs!
+  end
+
   def create_change_osr(import_level=0)
     raise ArgumentError.new('import_level must be 0, 1, or 2.') unless (0..2).include?(import_level)
     log "Load GTFS"

--- a/app/workers/feed_eater_worker.rb
+++ b/app/workers/feed_eater_worker.rb
@@ -37,10 +37,11 @@ class FeedEaterWorker
     end
 
     # Import feed
-    logger.info "FeedEaterWorker #{feed_onestop_id}: Importing feed at import level #{import_level}"
     graph = nil
     begin
+      logger.info "FeedEaterWorker #{feed_onestop_id}: Importing feed at import level #{import_level}"
       graph = GTFSGraph.new(feed_file_path, feed, feed_version)
+      graph.cleanup
       graph.create_change_osr(import_level)
       if import_level >= 2
         schedule_jobs = []

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -323,13 +323,5 @@ describe Feed do
       feed.activate_feed_version(fv2.sha1)
       expect(feed.active_feed_version).to eq(fv2)
     end
-
-    it 'cannot activate current active_feed_version' do
-      feed = create(:feed)
-      fv1 = create(:feed_version, feed: feed)
-      feed.activate_feed_version(fv1.sha1)
-      expect(feed.active_feed_version).to eq(fv1)
-      expect{feed.activate_feed_version(fv1.sha1)}.to raise_error(Exception)
-    end
   end
 end


### PR DESCRIPTION
Do not automatically remove old SSPs during Feed Version activation.

Remove restriction on calling Feed#activate_feed_version on current active feed.

Clean up any partial SSP imports before starting FeedEater job.

Resolves #426
Resolves #429