### PR TITLE
CORS headers will now be served by nginx, rather than the Rails app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'email_validator'
 gem 'text'
 
 # authentication and authorization
-gem 'rack-cors', require: 'rack/cors'
 gem 'devise'
 
 # providing API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,6 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     rack (1.6.4)
-    rack-cors (0.4.0)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -426,7 +425,6 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   pry-stack_explorer
-  rack-cors
   rails (= 4.2.5.1)
   rails-erd
   redis-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,12 +24,6 @@ module TransitlandDatastore
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-    config.middleware.insert_before 0, "Rack::Cors" do
-      allow do
-        origins '*'
-        resource '*', headers: :any, methods: [:get, :post, :put, :patch, :delete, :options]
-      end
-    end
 
     config.assets.enabled = false
 


### PR DESCRIPTION
related to https://github.com/mapzen/operations-engineering/issues/164