### PR TITLE
Add controller sorting

### DIFF
--- a/app/controllers/api/v1/change_payloads_controller.rb
+++ b/app/controllers/api/v1/change_payloads_controller.rb
@@ -17,6 +17,8 @@ class Api::V1::ChangePayloadsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @change_payloads,
           Proc.new { |params| api_v1_changeset_change_payloads_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/changesets_controller.rb
+++ b/app/controllers/api/v1/changesets_controller.rb
@@ -30,6 +30,8 @@ class Api::V1::ChangesetsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @changesets,
           Proc.new { |params| api_v1_changesets_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/feed_version_imports_controller.rb
+++ b/app/controllers/api/v1/feed_version_imports_controller.rb
@@ -27,6 +27,8 @@ class Api::V1::FeedVersionImportsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @feed_version_imports,
           Proc.new { |params| api_v1_feed_version_imports_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/feed_versions_controller.rb
+++ b/app/controllers/api/v1/feed_versions_controller.rb
@@ -69,6 +69,8 @@ class Api::V1::FeedVersionsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @feed_versions,
           Proc.new { |params| api_v1_feed_versions_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -27,6 +27,8 @@ class Api::V1::FeedsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @feeds,
           Proc.new { |params| api_v1_feeds_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/operators_controller.rb
+++ b/app/controllers/api/v1/operators_controller.rb
@@ -34,6 +34,8 @@ class Api::V1::OperatorsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @operators,
           Proc.new { |params| api_v1_operators_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/route_stop_patterns_controller.rb
+++ b/app/controllers/api/v1/route_stop_patterns_controller.rb
@@ -41,6 +41,8 @@ class Api::V1::RouteStopPatternsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @rsps,
           Proc.new { |params| api_v1_route_stop_patterns_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -49,6 +49,8 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
         render paginated_json_collection(
           @routes,
           Proc.new { |params| api_v1_routes_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -69,6 +69,8 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @ssps,
           Proc.new { |params| api_v1_schedule_stop_pairs_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/stops_controller.rb
+++ b/app/controllers/api/v1/stops_controller.rb
@@ -41,6 +41,8 @@ class Api::V1::StopsController < Api::V1::BaseApiController
         render paginated_json_collection(
           @stops,
           Proc.new { |params| api_v1_stops_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,6 +16,8 @@ class Api::V1::UsersController < Api::V1::BaseApiController
         render paginated_json_collection(
           @users,
           Proc.new { |params| api_v1_users_url(params) },
+          params[:sort_key],
+          params[:sort_order],
           params[:offset],
           params[:per_page],
           params[:total],

--- a/app/controllers/concerns/json_collection_pagination.rb
+++ b/app/controllers/concerns/json_collection_pagination.rb
@@ -2,10 +2,12 @@ module JsonCollectionPagination
   extend ActiveSupport::Concern
   PER_PAGE ||= 50
 
-  def paginated_json_collection(collection, path_helper, offset, per_page, total, params)
-    # Apply id as a default sort order;
-    #   will append to any existing sort orders.
-    collection = collection.order(:id)
+  def paginated_json_collection(collection, path_helper, sort_key, sort_order, offset, per_page, total, params)
+    #changing from order to reorder to discard previous ordering
+    sort_key = sort_key.presence || :id
+    sort_order = sort_order == 'desc' ? :desc : :asc
+    fail ArgumentError.new('Invalid sort_key') unless collection.column_names.include?(sort_key.to_s)
+    collection = collection.reorder(sort_key => sort_order)
 
     # Meta
     offset = (offset.presence || 0).to_i

--- a/app/controllers/concerns/json_collection_pagination.rb
+++ b/app/controllers/concerns/json_collection_pagination.rb
@@ -4,8 +4,8 @@ module JsonCollectionPagination
 
   def paginated_json_collection(collection, path_helper, sort_key, sort_order, offset, per_page, total, params)
     #changing from order to reorder to discard previous ordering
-    sort_key = sort_key.presence || :id
-    sort_order = sort_order == 'desc' ? :desc : :asc
+    sort_key = (sort_key.presence || :id).to_sym
+    sort_order = sort_order.to_s == 'desc' ? :desc : :asc
     fail ArgumentError.new('Invalid sort_key') unless collection.column_names.include?(sort_key.to_s)
     collection = collection.reorder(sort_key => sort_order)
 

--- a/app/controllers/concerns/json_collection_pagination.rb
+++ b/app/controllers/concerns/json_collection_pagination.rb
@@ -14,6 +14,8 @@ module JsonCollectionPagination
     per_page = (per_page.presence || self.class::PER_PAGE).to_i
     include_total = (total == true || total == 'true')
     meta = {
+        sort_key: sort_key,
+        sort_order: sort_order,
         offset: offset,
         per_page: per_page
     }
@@ -27,6 +29,8 @@ module JsonCollectionPagination
     # Previous and next page
     if offset > 0
       meta[:prev] = path_helper.call(params.merge({
+        sort_key: sort_key,
+        sort_order: sort_order,
         offset: (offset - per_page) >= 0 ? (offset - per_page) : 0,
         per_page: per_page,
         total: total
@@ -34,6 +38,8 @@ module JsonCollectionPagination
     end
     if data.size > per_page
       meta[:next] = path_helper.call(params.merge({
+        sort_key: sort_key,
+        sort_order: sort_order,
         offset: offset + per_page,
         per_page: per_page,
         total: total

--- a/spec/controllers/json_collection_pagination_spec.rb
+++ b/spec/controllers/json_collection_pagination_spec.rb
@@ -7,8 +7,12 @@ class FakePaginationCollection
   def column_names
     ['id']
   end
-  def reorder(key)
+  def reorder(**kwargs)
+    sort_key, sort_order = kwargs.first
     @items = @items.sort
+    if sort_order.to_sym == :desc
+      @items = @items.reverse
+    end
     self
   end
   def offset(i)
@@ -86,6 +90,28 @@ describe JsonCollectionPagination do
           per_page: 10
         }
       })
+    end
+
+    it 'sorts ascending' do
+      expect(
+        object.send(:paginated_json_collection, collection, path_helper, 'id', 'asc', 0, 10, false, {})[:json]
+      ).to eq(
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      )
+    end
+
+    it 'sorts descending' do
+      expect(
+        object.send(:paginated_json_collection, collection, path_helper, 'id', 'desc', 0, 10, false, {})[:json]
+      ).to eq(
+        [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+      )
+    end
+
+    it 'raises ArgumentError on invalid sort_key' do
+      expect {
+        object.send(:paginated_json_collection, collection, path_helper, 'unknown_key', 'desc', 0, 10, false, {})
+      }.to raise_error(ArgumentError)
     end
 
     it 'has a next page' do

--- a/spec/controllers/json_collection_pagination_spec.rb
+++ b/spec/controllers/json_collection_pagination_spec.rb
@@ -49,22 +49,10 @@ describe JsonCollectionPagination do
       ).to eq({
         json: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         meta: {
+          sort_key: :id,
+          sort_order: :asc,
           offset: 0,
           per_page: 10
-        }
-      })
-    end
-
-    it 'applies default sort order' do
-      expect(
-        object.send(:paginated_json_collection, collection_shuffle, path_helper, nil, nil, 4, 4, false, {})
-      ).to eq({
-        json: [4,5,6,7],
-        meta: {
-          offset: 4,
-          per_page: 4,
-          next: 'http://blah/offset=8',
-          prev: 'http://blah/offset=0'
         }
       })
     end
@@ -75,17 +63,9 @@ describe JsonCollectionPagination do
       ).to eq({
         json: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         meta: {
+          sort_key: :id,
+          sort_order: :asc,
           total: 10,
-          offset: 0,
-          per_page: 10
-        }
-      })
-
-      expect(
-        object.send(:paginated_json_collection, collection, path_helper, nil, nil, 0, 10, false, {})
-      ).to eq({
-        json: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        meta: {
           offset: 0,
           per_page: 10
         }

--- a/spec/controllers/json_collection_pagination_spec.rb
+++ b/spec/controllers/json_collection_pagination_spec.rb
@@ -4,7 +4,10 @@ class FakePaginationCollection
     @offset = 0
     @limit = @items.size
   end
-  def order(key)
+  def column_names
+    ['id']
+  end
+  def reorder(key)
     @items = @items.sort
     self
   end
@@ -33,12 +36,12 @@ describe JsonCollectionPagination do
   let(:path_helper) { Proc.new { |params| "http://blah/offset=#{params[:offset]}" } }
   let(:collection) { FakePaginationCollection.new((0...10).to_a) }
   let(:collection_shuffle) { FakePaginationCollection.new((0...10).to_a.shuffle) }
-  let(:pager) { Proc.new { |offset,per_page,total| object.send(:paginated_json_collection, collection, path_helper, offset, per_page, total, {}) } }
+  let(:pager) { Proc.new { |offset,per_page,total| object.send(:paginated_json_collection, collection, path_helper, nil, nil, offset, per_page, total, {}) } }
 
   context 'paginated_json_collection' do
     it 'one page' do
       expect(
-        object.send(:paginated_json_collection, collection, path_helper, 0, 10, false, {})
+        object.send(:paginated_json_collection, collection, path_helper, nil, nil, 0, 10, false, {})
       ).to eq({
         json: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         meta: {
@@ -50,7 +53,7 @@ describe JsonCollectionPagination do
 
     it 'applies default sort order' do
       expect(
-        object.send(:paginated_json_collection, collection_shuffle, path_helper, 4, 4, false, {})
+        object.send(:paginated_json_collection, collection_shuffle, path_helper, nil, nil, 4, 4, false, {})
       ).to eq({
         json: [4,5,6,7],
         meta: {
@@ -64,7 +67,7 @@ describe JsonCollectionPagination do
 
     it 'has an optional total' do
       expect(
-        object.send(:paginated_json_collection, collection, path_helper, 0, 10, true, {})
+        object.send(:paginated_json_collection, collection, path_helper, nil, nil, 0, 10, true, {})
       ).to eq({
         json: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         meta: {
@@ -75,7 +78,7 @@ describe JsonCollectionPagination do
       })
 
       expect(
-        object.send(:paginated_json_collection, collection, path_helper, 0, 10, false, {})
+        object.send(:paginated_json_collection, collection, path_helper, nil, nil, 0, 10, false, {})
       ).to eq({
         json: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
         meta: {


### PR DESCRIPTION
This PR adds a sort key and a sort order to the paginated_json_collection, and updates entity controllers.

closes #440 