### PR TITLE
Unreferenced entity cleanup

### DIFF
--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -1,6 +1,6 @@
 namespace :db do
   namespace :cleanup do
-    desc 'Deleting entities belonging only to inactive feed versions. [0] : logging mode, [1] : delete mode.'
+    desc 'Deleting entities belonging only to inactive feed versions ([0]: logging mode, [1]: delete mode).'
     task :cleanup_unreferenced_entities, [:mode] => [:environment] do |t, args|
       args.with_defaults(:mode => 0)
       mode = args[:mode].to_i
@@ -41,6 +41,12 @@ namespace :db do
         puts "Error: #{$!.message}"
         puts $!.backtrace
       end
+    end
+
+    desc 'Deleting ScheduleStopPairs belonging only to inactive feed versions ([0]: logging mode, [1]: delete mode).'
+    task :cleanup_unreferenced_ssps, [:mode] => [:environment] do |t, args|
+      # TODO:
+      # ScheduleStopPair.where(feed_version: FeedVersion.where.not(id: Feed.select(:active_feed_version_id)))
     end
   end
 end

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -13,7 +13,7 @@ namespace :db do
             route_serving_stops = RouteServingStop.where(route_id: entities_to_delete_ids)
             puts "Found #{route_serving_stops.size} RouteServingStops to delete."
             if (mode == 1 && !route_serving_stops.empty?)
-              puts "Deleting RouteServingStops."
+              puts "Deleting unreferenced RouteServingStops."
               route_serving_stops.delete_all
             end
           end
@@ -21,19 +21,19 @@ namespace :db do
             operator_serving_stops = OperatorServingStop.where(stop_id: entities_to_delete_ids)
             puts "Found #{operator_serving_stops.size} OperatorServingStops to delete."
             if (mode == 1 && !operator_serving_stops.empty?)
-              puts "Deleting OperatorServingStops."
+              puts "Deleting unreferenced OperatorServingStops."
               operator_serving_stops.delete_all
             end
           end
           entities_imported = EntityImportedFromFeed.where(entity_id: entities_to_delete_ids, entity_type: entity.to_s)
           puts "Found #{entities_imported.size} EntityImportedFromFeed #{entity.to_s}s to delete."
           if (mode && !entities_imported.empty?)
-            puts "Deleting EntityImportedFromFeed #{entity.to_s}s."
+            puts "Deleting unreferenced EntityImportedFromFeed #{entity.to_s}s."
             entities_imported.delete_all
           end
           puts "Found #{entities_to_delete.size} #{entity.to_s}s to delete."
           if (mode == 1 && !entities_to_delete.empty?)
-            puts "Deleting #{entity.to_s}s."
+            puts "Deleting unreferenced #{entity.to_s}s."
             entities_to_delete.each { |e| e.delete }
           end
         end

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -1,22 +1,20 @@
 namespace :db do
   namespace :cleanup do
     desc 'Deleting entities belonging only to inactive feed versions'
-    task :cleanup_entities, [] => [:environment] do |t, args|
+    task :cleanup_unreferenced_entities, [] => [:environment] do |t, args|
       begin
         [Stop,Route,RouteStopPattern,Operator].each do |entity|
-          imported_entities = EntityImportedFromFeed.select(:entity_id)
-            .where.not(feed_version_id: Feed.select(:active_feed_version_id))
-            .where(entity_type: entity.to_s)
-          entity.where(id: imported_entities).delete_all
+          entities_to_delete = entity.where('').reject { |e| e.imported_from_feed_versions.any?(&:is_active_feed_version) }
+          entities_to_delete_ids = entities_to_delete.map(&:id)
           if (entity == Route)
-            RouteServingStop.where(route_id: imported_entities.uniq).delete_all
+            RouteServingStop.where(route_id: entities_to_delete_ids).delete_all
           end
           if (entity == Operator)
-            OperatorServingStop.where(operator_id: imported_entities.uniq).delete_all
+            OperatorServingStop.where(operator_id: entities_to_delete_ids).delete_all
           end
-          imported_entities.delete_all
+          EntityImportedFromFeed.where(entity_id: entities_to_delete_ids).delete_all
+          entities_to_delete.each { |e| e.delete }
         end
-        # old tables?
       rescue
         puts "Error: #{$!.message}"
         puts $!.backtrace

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -1,19 +1,41 @@
 namespace :db do
   namespace :cleanup do
-    desc 'Deleting entities belonging only to inactive feed versions'
-    task :cleanup_unreferenced_entities, [] => [:environment] do |t, args|
+    desc 'Deleting entities belonging only to inactive feed versions. [0] : logging mode, [1] : delete mode.'
+    task :cleanup_unreferenced_entities, [:mode] => [:environment] do |t, args|
+      args.with_defaults(:mode => 0)
+      mode = args[:mode].to_i
+      puts mode == 0 ? "logging mode" : "delete mode"
       begin
         [Stop,Route,RouteStopPattern].each do |entity|
           entities_to_delete = entity.where('').reject { |e| e.imported_from_feed_versions.any?(&:is_active_feed_version) }
           entities_to_delete_ids = entities_to_delete.map(&:id)
           if (entity == Route)
-            RouteServingStop.where(route_id: entities_to_delete_ids).delete_all
+            route_serving_stops = RouteServingStop.where(route_id: entities_to_delete_ids)
+            puts "Found #{route_serving_stops.size} RouteServingStops to delete."
+            if (mode == 1 && !route_serving_stops.empty?)
+              puts "Deleting RouteServingStops."
+              route_serving_stops.delete_all
+            end
           end
           if (entity == Stop)
-            OperatorServingStop.where(stop_id: entities_to_delete_ids).delete_all
+            operator_serving_stops = OperatorServingStop.where(stop_id: entities_to_delete_ids)
+            puts "Found #{operator_serving_stops.size} OperatorServingStops to delete."
+            if (mode == 1 && !operator_serving_stops.empty?)
+              puts "Deleting OperatorServingStops."
+              operator_serving_stops.delete_all
+            end
           end
-          EntityImportedFromFeed.where(entity_id: entities_to_delete_ids, entity_type: entity.to_s).delete_all
-          entities_to_delete.each { |e| e.delete }
+          entities_imported = EntityImportedFromFeed.where(entity_id: entities_to_delete_ids, entity_type: entity.to_s)
+          puts "Found #{entities_imported.size} EntityImportedFromFeed #{entity.to_s}s to delete."
+          if (mode && !entities_imported.empty?)
+            puts "Deleting EntityImportedFromFeed #{entity.to_s}s."
+            entities_imported.delete_all
+          end
+          puts "Found #{entities_to_delete.size} #{entity.to_s}s to delete."
+          if (mode == 1 && !entities_to_delete.empty?)
+            puts "Deleting #{entity.to_s}s."
+            entities_to_delete.each { |e| e.delete }
+          end
         end
       rescue
         puts "Error: #{$!.message}"

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -3,14 +3,20 @@ namespace :db do
     desc 'Deleting entities belonging only to inactive feed versions'
     task :cleanup_entities, [] => [:environment] do |t, args|
       begin
-        #EntityImportedFromFeed.includes(:feed_version).all.each do |eifv|
-        #  eifv.entity_type
-        #end
-        #[RouteStopPattern, Stop, Route, Operator, OperatorServingStop, RouteServingStop].each do |entity|
-        #  entity.where('').select { |obj| obj.imported_from_feed_versions.any?(&:is_active_feed_version) }.each do |o|
-        #    o.destroy
-        #  end
-        #end
+        [Stop,Route,RouteStopPattern,Operator].each do |entity|
+          imported_entities = EntityImportedFromFeed.select(:entity_id)
+            .where.not(feed_version_id: Feed.select(:active_feed_version_id))
+            .where(entity_type: entity.to_s)
+          entity.where(id: imported_entities).delete_all
+          if (entity == Route)
+            RouteServingStop.where(route_id: imported_entities.uniq).delete_all
+          end
+          if (entity == Operator)
+            OperatorServingStop.where(operator_id: imported_entities.uniq).delete_all
+          end
+          imported_entities.delete_all
+        end
+        # old tables?
       rescue
         puts "Error: #{$!.message}"
         puts $!.backtrace

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -1,0 +1,20 @@
+namespace :db do
+  namespace :cleanup do
+    desc 'Deleting entities belonging only to inactive feed versions'
+    task :cleanup_entities, [] => [:environment] do |t, args|
+      begin
+        #EntityImportedFromFeed.includes(:feed_version).all.each do |eifv|
+        #  eifv.entity_type
+        #end
+        #[RouteStopPattern, Stop, Route, Operator, OperatorServingStop, RouteServingStop].each do |entity|
+        #  entity.where('').select { |obj| obj.imported_from_feed_versions.any?(&:is_active_feed_version) }.each do |o|
+        #    o.destroy
+        #  end
+        #end
+      rescue
+        puts "Error: #{$!.message}"
+        puts $!.backtrace
+      end
+    end
+  end
+end

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -3,16 +3,16 @@ namespace :db do
     desc 'Deleting entities belonging only to inactive feed versions'
     task :cleanup_unreferenced_entities, [] => [:environment] do |t, args|
       begin
-        [Stop,Route,RouteStopPattern,Operator].each do |entity|
+        [Stop,Route,RouteStopPattern].each do |entity|
           entities_to_delete = entity.where('').reject { |e| e.imported_from_feed_versions.any?(&:is_active_feed_version) }
           entities_to_delete_ids = entities_to_delete.map(&:id)
           if (entity == Route)
             RouteServingStop.where(route_id: entities_to_delete_ids).delete_all
           end
-          if (entity == Operator)
-            OperatorServingStop.where(operator_id: entities_to_delete_ids).delete_all
+          if (entity == Stop)
+            OperatorServingStop.where(stop_id: entities_to_delete_ids).delete_all
           end
-          EntityImportedFromFeed.where(entity_id: entities_to_delete_ids).delete_all
+          EntityImportedFromFeed.where(entity_id: entities_to_delete_ids, entity_type: entity.to_s).delete_all
           entities_to_delete.each { |e| e.delete }
         end
       rescue


### PR DESCRIPTION
Resolves #473.
Rake task for removing entities (except operators) not associated with any active feed version.