### PR TITLE
logging for equal consecutive distances and segment mismatch case

### DIFF
--- a/app/models/route_stop_pattern.rb
+++ b/app/models/route_stop_pattern.rb
@@ -144,6 +144,9 @@ class RouteStopPattern < BaseRouteStopPattern
           total_distance += RGeo::Feature.cast(splits[0], RouteStopPattern::GEOFACTORY).length
           distances << total_distance.round(DISTANCE_PRECISION)
         end
+        if (i != 0 && distances[i-1] == distances[i])
+          logger.info "stop #{self.stop_pattern[i]} has the same distance as #{self.stop_pattern[i-1]}, which may indicate a segment matching issue."
+        end
         cast_route = splits[1]
       end
       if (distances[i] > geometry_length)


### PR DESCRIPTION
Some issue with RSP distance calculation were not being logged; namely, non-outlier stops with consecutive equal distances.