### PR TITLE
Rsp single metric log

### DIFF
--- a/app/models/route_stop_pattern.rb
+++ b/app/models/route_stop_pattern.rb
@@ -32,7 +32,7 @@ class BaseRouteStopPattern < ActiveRecord::Base
 
   include IsAnEntityImportedFromFeeds
 
-  attr_accessor :traversed_by
+  attr_accessor :traversed_by, :passable_distances
 end
 
 class RouteStopPattern < BaseRouteStopPattern
@@ -115,6 +115,7 @@ class RouteStopPattern < BaseRouteStopPattern
     # TODO: potential issue with nearest stop segment matching after subsequent stop
     # TODO: investigate 'boundary' lat/lng possibilities
     distances = []
+    self.passable_distances = true
     total_distance = 0.0
     cartesian_factory = RGeo::Cartesian::Factory.new(srid: 4326)
     cast_route = RGeo::Feature.cast(self[:geometry], cartesian_factory)
@@ -128,6 +129,7 @@ class RouteStopPattern < BaseRouteStopPattern
         # So this might be an outlier stop. Another possibility might be 2 consecutive stops
         # having the same coordinates.
         logger.info "stop #{stop.onestop_id}, number #{i+1}, within route stop pattern #{self.onestop_id} may be an outlier or indicate invalid geometry"
+        self.passable_distances = false
         # TODO add interpolated distance at halfway and split line there?
         # if so, will need to take into account case of 2 consecutive stops having same location.
         if (i == 0 && splits[1].nil?)
@@ -148,9 +150,11 @@ class RouteStopPattern < BaseRouteStopPattern
       end
       if (distances[i] > geometry_length)
         logger.info "stop #{stop.onestop_id}, number #{i+1}, of route stop pattern #{self.onestop_id} has a distance greater than the length of the geometry"
+        self.passable_distances = false
       end
       if (i != 0 && distances[i-1] > distances[i])
         logger.info "stop #{self.stop_pattern[i]} occurs after stop #{self.stop_pattern[i-1]} but has a distance less than #{self.stop_pattern[i-1]}"
+        self.passable_distances = false
       end
     end
     distances

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -107,7 +107,7 @@ class GTFSGraph
         rsps_with_issues += 1
       end
     end
-    score = ((rsp_map.values.size - rsps_with_issues)/rsp_map.values.size.to_f).round(3) rescue score = 1.0
+    score = ((rsp_map.values.size - rsps_with_issues)/rsp_map.values.size.to_f).round(5) rescue score = 1.0
     log "#{rsps_with_issues} Route Stop Patterns out of #{rsp_map.values.size} had issues with distance calculation. Valhalla Import Score: #{score}"
     log "Create: SSPs"
     total = 0


### PR DESCRIPTION
Closes #466 

After calculating distances for all RouteStopPatterns in feed import, log a score that is the percentage of RouteStopPatterns with issues (outlier stops, distances decreasing in value instead of increasing, etc.).

Useful for making a determination of whether to send feed distances to Valhalla.