### PR TITLE
allow users to query API for all routes that have a color defined

### DIFF
--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -50,7 +50,11 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       @routes = @routes.stop_within_bbox(params[:bbox])
     end
     if params[:color].present?
-      @routes = @routes.where(color: params[:color])
+      if ['true', true].include?(params[:color])
+        @routes = @routes.where.not(color: nil)
+      else
+        @routes = @routes.where(color: params[:color].upcase)
+      end
     end
 
     @routes = @routes.includes{[

--- a/spec/controllers/api/v1/routes_controller_spec.rb
+++ b/spec/controllers/api/v1/routes_controller_spec.rb
@@ -111,6 +111,21 @@ describe Api::V1::RoutesController do
           expect(routes.length).to eq 0
         }})
       end
+
+      it 'returns all routes with a defined color' do
+        get :index, color: 'true'
+        expect_json({ routes: -> (routes) {
+          expect(routes.length).to eq 0
+        }})
+      end
+
+      it 'returns all routes with a specified color' do
+        Route.first.update(color: 'CCEEFF')
+        get :index, color: 'cceeff'
+        expect_json({ routes: -> (routes) {
+          expect(routes.length).to eq 1
+        }})
+      end
     end
 
     context 'as CSV' do


### PR DESCRIPTION
`/api/v1/routes?color=true` (should use the color attribute on the Route model, rather than the tag)

closes #514