### PR TITLE
Maximum Onestop ID Length

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -36,8 +36,6 @@ end
 class Stop < BaseStop
   self.table_name_prefix = 'current_'
 
-  GEOHASH_PRECISION = 10
-
   include HasAOnestopId
   include IsAnEntityWithIdentifiers
   include HasAGeographicGeometry
@@ -256,7 +254,7 @@ class Stop < BaseStop
   def self.from_gtfs(entity, attrs={})
     # GTFS Constructor
     point = Stop::GEOFACTORY.point(*entity.coordinates)
-    geohash = GeohashHelpers.encode(point, precision=GEOHASH_PRECISION)
+    geohash = GeohashHelpers.encode(point)
     name = [entity.stop_name, entity.id, "unknown"]
       .select(&:present?)
       .first

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -13,6 +13,8 @@ module OnestopId
     PREFIX = nil
     MODEL = nil
     NUM_COMPONENTS = 3
+    MAX_LENGTH = 64
+    GEOHASH_MAX_LENGTH = 10
 
     attr_accessor :geohash, :name
 
@@ -32,7 +34,11 @@ module OnestopId
     end
 
     def to_s
-      [self.class::PREFIX, @geohash, @name].join(COMPONENT_SEPARATOR)
+      [
+        self.class::PREFIX,
+        @geohash[0...self.class::GEOHASH_MAX_LENGTH],
+        @name
+      ].join(COMPONENT_SEPARATOR)[0...self.class::MAX_LENGTH]
     end
 
     def validate
@@ -113,7 +119,13 @@ module OnestopId
     end
 
     def to_s
-      [self.class::PREFIX, @geohash, @name, @stop_hash, @geometry_hash].join(COMPONENT_SEPARATOR)
+      [
+        self.class::PREFIX,
+        @geohash[0...self.class::GEOHASH_MAX_LENGTH],
+        @name,
+        @stop_hash,
+        @geometry_hash
+      ].join(COMPONENT_SEPARATOR)[0...self.class::MAX_LENGTH]
     end
 
     def validate

--- a/spec/services/onestop_id_spec.rb
+++ b/spec/services/onestop_id_spec.rb
@@ -3,6 +3,8 @@ class TestOnestopId < OnestopId::OnestopIdBase
   PREFIX = :s
   MODEL = Stop
   NUM_COMPONENTS = 3
+  GEOHASH_MAX_LENGTH = 5
+  MAX_LENGTH = 32
 end
 
 describe OnestopId do
@@ -20,6 +22,26 @@ describe OnestopId do
     expect {
       TestOnestopId.new(geohash: '9q9')
     }.to raise_error(ArgumentError)
+  end
+
+  context 'max length' do
+    it 'truncates beyond maximum length' do
+      expect(
+        TestOnestopId.new(
+          geohash: '9q9',
+          name: 'pneumonoultramicroscopicsilicovolcanoconiosis'
+        ).to_s
+      ).to eq('s-9q9-pneumonoultramicroscopicsi')
+    end
+
+    it 'truncates beyond maximum geohash length' do
+      expect(
+        TestOnestopId.new(
+          geohash: '1234567890',
+          name: 'name'
+        ).to_s
+      ).to eq('s-12345-name')
+    end
   end
 
   context '#geohash' do


### PR DESCRIPTION
Provide mechanism for Onestop ID handlers to implement maximum lengths: geohash and total length

Resolves #512