### PR TITLE
Interpolation of outlier stops

### DIFF
--- a/app/models/route_stop_pattern.rb
+++ b/app/models/route_stop_pattern.rb
@@ -234,7 +234,8 @@ class RouteStopPattern < BaseRouteStopPattern
         elsif (i==stops.size-1)
           self.stop_distances << self[:geometry].length
         else
-          self.stop_distances << self.stop_distances[i-1]
+          # interpolate using half the distance between previous and next stop
+          self.stop_distances << self.stop_distances[i-1] + stops[i-1][:geometry].distance(stops[i+1][:geometry])/2.0
         end
       else
         self.stop_distances << distance

--- a/spec/models/route_stop_pattern_spec.rb
+++ b/spec/models/route_stop_pattern_spec.rb
@@ -348,7 +348,7 @@ describe RouteStopPattern do
                            stop_c.onestop_id]
       expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
                                                               a_value_within(0.1).of(12617.9271),
-                                                              a_value_within(0.1).of(12617.9271),
+                                                              a_value_within(0.1).of(14809.7),
                                                               a_value_within(0.1).of(17001.5107)])
     end
 


### PR DESCRIPTION
Interpolation using half the distance between previous and next stop. Also removes duplicate issue count, in case that integer value itself is assessed beyond >= 0.