### PR TITLE
allow download of feed versions from CDN

### DIFF
--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -63,6 +63,15 @@ class FeedVersion < ActiveRecord::Base
     )
   end
 
+  def download_url
+    if self.feed.license_redistribute.presence == 'no'
+      nil
+    else
+      # we don't want to include any query parameters
+      self.file.url.split('?').first
+    end
+  end
+
   private
 
   def compute_and_set_hashes

--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -66,7 +66,7 @@ class FeedVersion < ActiveRecord::Base
   def download_url
     if self.feed.license_redistribute.presence == 'no'
       nil
-    else
+    elsif self.try(:file).try(:url)
       # we don't want to include any query parameters
       self.file.url.split('?').first
     end

--- a/app/serializers/feed_version_serializer.rb
+++ b/app/serializers/feed_version_serializer.rb
@@ -37,7 +37,8 @@ class FeedVersionSerializer < ApplicationSerializer
              :feed_version_imports_url,
              :import_level,
              :is_active_feed_version,
-             :changesets_imported_from_this_feed_version
+             :changesets_imported_from_this_feed_version,
+             :download_url
 
   def feed_version_imports
     object.feed_version_imports.map(&:id)

--- a/spec/models/feed_version_spec.rb
+++ b/spec/models/feed_version_spec.rb
@@ -66,4 +66,19 @@ describe FeedVersion do
     expect(inactive_feed_version.is_active_feed_version).to eq false
   end
 
+  context 'download url' do
+    it 'is included by default' do
+      feed = create(:feed)
+      feed_version = create(:feed_version, feed: feed)
+      allow(feed_version).to receive_message_chain(:file, :url).and_return('http://cloudfront.com/file/f-9q9-bart.zip?auth=1')
+      expect(feed_version.download_url).to eq('http://cloudfront.com/file/f-9q9-bart.zip')
+    end
+
+    it "isn't included for feeds that don't allow redistribution" do
+      feed = create(:feed, license_redistribute: 'no')
+      feed_version = create(:feed_version, feed: feed)
+      allow(feed_version).to receive_message_chain(:file, :url).and_return('http://cloudfront.com/')
+      expect(feed_version.download_url).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
as long as redistribution is allowed for that feed

closes #404