### PR TITLE
Onestop ID exceptions, name fallbacks

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -254,15 +254,16 @@ class Stop < BaseStop
     # GTFS Constructor
     point = Stop::GEOFACTORY.point(*entity.coordinates)
     geohash = GeohashHelpers.encode(point)
-    name = [entity.stop_name, entity.id, "unknown"]
-      .select(&:present?)
-      .first
-    onestop_id = OnestopId.handler_by_model(self).new(
-      geohash: geohash,
-      name: name
-    )
+    # Use stop_id as a fallback for an invalid onestop ID name component
+    onestop_id = OnestopId.handler_by_model(self).new(geohash: geohash, name: entity.stop_name)
+    if onestop_id.valid? == false
+      old_onestop_id = onestop_id.to_s
+      onestop_id = OnestopId.handler_by_model(self).new(geohash: geohash, name: entity.id)
+      logger.info "Stop.from_gtfs: Invalid onestop_id: #{old_onestop_id}, trying #{onestop_id.to_s}"
+    end
+    onestop_id.validate! # raise OnestopIdException
     stop = Stop.new(
-      name: name,
+      name: entity.stop_name,
       onestop_id: onestop_id.to_s,
       geometry: point.to_s
     )

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -8,6 +8,9 @@ module OnestopId
   NAME_FILTER = /[^[:alnum:]\~\>\<]/
   IDENTIFIER_TEMPLATE = Addressable::Template.new("gtfs://{feed_onestop_id}/{entity_prefix}/{entity_id}")
 
+  class OnestopIdException < StandardError
+  end
+
   class OnestopIdBase
 
     PREFIX = nil
@@ -48,6 +51,11 @@ module OnestopId
       errors << 'invalid geohash' unless validate_geohash(@geohash)
       errors << 'invalid name' unless validate_name(@name)
       return (errors.size == 0), errors
+    end
+
+    def validate!
+      valid, errors = self.validate
+      raise OnestopIdException.new(errors.join(', ')) unless valid
     end
 
     def valid?


### PR DESCRIPTION
Stop.from_gtfs uses the stop 'stop_name' to generate the OnestopID. However, if this is a string that only contains filtered out characters, e.g. '_', it will generate an empty OnestopID which will fail validation. This PR falls back to the stop 'stop_id' in this case.

Resolves #583
Resolves https://github.com/transitland/transitland/issues/51