### PR TITLE
Temporary file cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', tag: '6c8ef14663b1ca57127b1056344a650a6941adf9'
+gem 'gtfs', github: 'transitland/gtfs', tag: '4f99e646ed51763f318310ee4d5fc48d06e3402b'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema', '2.5.2' # running into problems with 2.6.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GIT
 
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: 6c8ef14663b1ca57127b1056344a650a6941adf9
-  tag: 6c8ef14663b1ca57127b1056344a650a6941adf9
+  revision: 4f99e646ed51763f318310ee4d5fc48d06e3402b
+  tag: 4f99e646ed51763f318310ee4d5fc48d06e3402b
   specs:
     gtfs (1.0.1)
       multi_json
@@ -192,7 +192,6 @@ GEM
       activerecord (>= 2.3)
     method_source (0.8.2)
     mime-types (2.99.1)
-    mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     minitest (5.9.0)
     mock_redis (0.16.1)

--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -75,8 +75,9 @@ class FeedVersion < ActiveRecord::Base
 
   def open_gtfs
     fail StandardError.new('No file') unless file.present?
-    @gtfs ||= GTFS::Source.build(file.local_path_copying_locally_if_needed, {strict: false})
-    @gtfs
+    filename = file.local_path_copying_locally_if_needed
+    yield GTFS::Source.build(filename, {strict: false})
+    file.remove_any_local_cached_copies
   end
 
   def fetch_and_normalize

--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -102,6 +102,9 @@ class FeedVersion < ActiveRecord::Base
     end
     # Compute hashes
     compute_and_set_hashes
+    # Cleanup
+    self.file.remove_any_local_cached_copies if self.file
+    self.file_raw.remove_any_local_cached_copies if self.file_raw
   end
 
   def url_fragment

--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -42,7 +42,7 @@ class FeedVersion < ActiveRecord::Base
   validates :sha1, presence: true, uniqueness: true
   validates :feed, presence: true
 
-  before_validation :compute_and_set_hashes, :read_gtfs_calendar_dates, :read_gtfs_feed_info
+  before_validation :compute_and_set_hashes, :read_gtfs_info
 
   scope :where_active, -> {
     joins('INNER JOIN current_feeds ON feed_versions.id = current_feeds.active_feed_version_id')
@@ -130,35 +130,30 @@ class FeedVersion < ActiveRecord::Base
     end
   end
 
-  def read_gtfs_calendar_dates
+  def read_gtfs_info
     if file.present? && file_changed?
-      gtfs = open_gtfs
-      start_date, end_date = gtfs.service_period_range
-      self.earliest_calendar_date ||= start_date
-      self.latest_calendar_date ||= end_date
-    end
-  end
-
-  def read_gtfs_feed_info
-    if file.present? && file_changed?
-      gtfs = open_gtfs
-      begin
-        if gtfs.feed_infos.count > 0
-          feed_info = gtfs.feed_infos[0]
-          feed_version_tags = {
-            feed_publisher_name: feed_info.feed_publisher_name,
-            feed_publisher_url:  feed_info.feed_publisher_url,
-            feed_lang:           feed_info.feed_lang,
-            feed_start_date:     feed_info.feed_start_date,
-            feed_end_date:       feed_info.feed_end_date,
-            feed_version:        feed_info.feed_version,
-            feed_id:             feed_info.feed_id
-          }
-          feed_version_tags.delete_if { |k, v| v.blank? }
-          self.tags = feed_version_tags
+      open_gtfs do |gtfs|
+        start_date, end_date = gtfs.service_period_range
+        self.earliest_calendar_date ||= start_date
+        self.latest_calendar_date ||= end_date
+        begin
+          if gtfs.feed_infos.count > 0
+            feed_info = gtfs.feed_infos[0]
+            feed_version_tags = {
+              feed_publisher_name: feed_info.feed_publisher_name,
+              feed_publisher_url:  feed_info.feed_publisher_url,
+              feed_lang:           feed_info.feed_lang,
+              feed_start_date:     feed_info.feed_start_date,
+              feed_end_date:       feed_info.feed_end_date,
+              feed_version:        feed_info.feed_version,
+              feed_id:             feed_info.feed_id
+            }
+            feed_version_tags.delete_if { |k, v| v.blank? }
+            self.tags = feed_version_tags
+          end
+        rescue GTFS::InvalidSourceException
+          return
         end
-      rescue GTFS::InvalidSourceException
-        return
       end
     end
   end

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -10,7 +10,9 @@ class GTFSGraph
     # GTFS Graph / TransitLand wrapper
     @feed = feed
     @feed_version = feed_version
-    @gtfs = @feed_version.open_gtfs
+    @gtfs = nil
+    @feed_version.open_gtfs { |gtfs| @gtfs = gtfs }
+
     @log = []
     # GTFS entity to Onestop ID
     @gtfs_to_onestop_id = {}

--- a/app/uploaders/feed_version_uploader.rb
+++ b/app/uploaders/feed_version_uploader.rb
@@ -29,8 +29,8 @@ class FeedVersionUploader < CarrierWave::Uploader::Base
   end
 
   def remove_any_local_cached_copies
-    if cached?
-      FileUtils.rm_rf(File.dirname(path))
+    if url.start_with?('http')
+      FileUtils.rm_rf(File.dirname(path)) if cached?
     end
   end
 end

--- a/app/uploaders/feed_version_uploader.rb
+++ b/app/uploaders/feed_version_uploader.rb
@@ -22,14 +22,14 @@ class FeedVersionUploader < CarrierWave::Uploader::Base
   end
 
   def local_path_copying_locally_if_needed
-    if url.start_with?('http')
+    if url && url.start_with?('http')
       cache_stored_file! unless cached?
     end
     path
   end
 
   def remove_any_local_cached_copies
-    if url.start_with?('http')
+    if url && url.start_with?('http')
       FileUtils.rm_rf(File.dirname(path)) if cached?
     end
   end

--- a/spec/models/feed_version_spec.rb
+++ b/spec/models/feed_version_spec.rb
@@ -41,15 +41,12 @@ describe FeedVersion do
     end
   end
 
-  context '#read_gtfs_calendar_dates' do
+  context '#read_gtfs_info' do
     it 'reads earliest and latest dates from calendars.txt' do
       feed_version = create(:feed_version_bart)
       expect(feed_version.earliest_calendar_date).to eq Date.parse('2013-11-28')
       expect(feed_version.latest_calendar_date).to eq Date.parse('2017-01-01')
     end
-  end
-
-  context '#read_gtfs_feed_info' do
     it 'reads feed_info.txt and puts into tags' do
       feed_version = create(:feed_version_bart)
       expect(feed_version.tags['feed_lang']).to eq 'en'


### PR DESCRIPTION
Upgrade gtfs gem to latest commit to resolve temporary file cleanup issue.

Refactor FeedVersion.open_gtfs to open/close/cleanup cached gtfs in a block.

Resolve #594 
