### PR TITLE
Rake task: enqueue next feed version

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -227,7 +227,7 @@ class Feed < BaseFeed
       .first
   end
 
-  def queue_next_feed_version(date, import_level=nil)
+  def enqueue_next_feed_version(date, import_level=nil)
     # Enqueue FeedEater job for self.find_next_feed_version
     # Use the previous import_level, or default to 2
     import_level ||= self.active_feed_version.try(:import_level) || 2

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -111,17 +111,6 @@ class Feed < BaseFeed
     })
   }
 
-  def find_next_feed_versions(date: nil)
-    # Find the most recently created feed_version that will have service
-    # on (date) and is newer than the active_feed_version.
-    date ||= DateTime.now
-    earliest_active = active_feed_version.try(:earliest_calendar_date)
-    feed_versions
-      .where('earliest_calendar_date > ?', earliest_active)
-      .where('earliest_calendar_date <= ?', date)
-      .reorder(earliest_calendar_date: :desc, created_at: :desc)
-  end
-
   include CurrentTrackedByChangeset
   current_tracked_by_changeset({
     kind_of_model_tracked: :onestop_entity,

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -111,6 +111,17 @@ class Feed < BaseFeed
     })
   }
 
+  def find_next_feed_versions(date: nil)
+    # Find the most recently created feed_version that will have service
+    # on (date) and is newer than the active_feed_version.
+    date ||= DateTime.now
+    earliest_active = active_feed_version.try(:earliest_calendar_date)
+    feed_versions
+      .where('earliest_calendar_date > ?', earliest_active)
+      .where('earliest_calendar_date <= ?', date)
+      .reorder(earliest_calendar_date: :desc, created_at: :desc)
+  end
+
   include CurrentTrackedByChangeset
   current_tracked_by_changeset({
     kind_of_model_tracked: :onestop_entity,

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -234,6 +234,8 @@ class Feed < BaseFeed
     # Find the next feed_version
     next_feed_version = self.find_next_feed_version(date)
     return unless next_feed_version
+    # Return if it's been imported before
+    return if next_feed_version.feed_version_imports.last
     # Enqueue
     FeedEaterWorker.perform_async(
       self.onestop_id,

--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -65,14 +65,6 @@ class FeedVersion < ActiveRecord::Base
     !!self.feed.active_feed_version && (self.feed.active_feed_version == self)
   end
 
-  def async_feed_eater(import_level=0)
-    FeedEaterWorker.perform_async(
-      self.feed.onestop_id,
-      self.sha1,
-      import_level
-    )
-  end
-
   def open_gtfs
     fail StandardError.new('No file') unless file.present?
     filename = file.local_path_copying_locally_if_needed

--- a/app/workers/feed_eater_schedule_worker.rb
+++ b/app/workers/feed_eater_schedule_worker.rb
@@ -1,7 +1,7 @@
 class FeedEaterScheduleWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :feed_eater_schedule
+  sidekiq_options queue: :feed_eater_schedule, retry: false
 
   def perform(feed_onestop_id, feed_version_sha1, feed_schedule_import_id, trip_ids, agency_map, route_map, stop_map, rsp_map)
     logger.info "FeedEaterScheduleWorker #{feed_onestop_id}: Importing #{trip_ids.size} trips"

--- a/app/workers/feed_eater_worker.rb
+++ b/app/workers/feed_eater_worker.rb
@@ -4,7 +4,8 @@ class FeedEaterWorker
   sidekiq_options unique: :until_and_while_executing,
                   unique_job_expiration: 60 * 60, # 1 hour
                   log_duplicate_payload: true,
-                  queue: :feed_eater
+                  queue: :feed_eater,
+                  retry: false
 
   FEEDVALIDATOR_PATH = './virtualenv/bin/feedvalidator.py'
 

--- a/lib/tasks/enqueue_next_feed_version.rake
+++ b/lib/tasks/enqueue_next_feed_version.rake
@@ -1,0 +1,36 @@
+task :enqueue_next_feed_version, [:date] => [:environment] do |t, args|
+  date = Date.parse(args.date)
+  Feed.find_each do |feed|
+    # Check for active_feed_version
+    active_feed_version = feed.active_feed_version
+    next unless active_feed_version
+    # Find the most recently created feed_version that will have service
+    # on (date) and is newer than the active_feed_version.
+    next_feed_version = feed
+      .feed_versions
+      .where('earliest_calendar_date > ?', active_feed_version.earliest_calendar_date)
+      .where('earliest_calendar_date <= ?', date)
+      .reorder(earliest_calendar_date: :desc, created_at: :desc)
+      .first
+    next unless next_feed_version
+    # Check for any previous import
+    next if next_feed_version.feed_version_imports.last
+    # Enqueue
+    import_level = feed.active_feed_version.import_level || 2
+    puts "Feed: #{feed.onestop_id}"
+    puts "  active_feed_version sha1: #{active_feed_version.sha1}"
+    puts "  active_feed_version date: #{active_feed_version.earliest_calendar_date} - #{active_feed_version.latest_calendar_date}"
+    puts "  next_feed_version   sha1: #{next_feed_version.sha1}"
+    puts "  next_feed_version   date: #{next_feed_version.earliest_calendar_date} - #{next_feed_version.latest_calendar_date}"
+    worker_id = FeedEaterWorker.perform_async(
+      feed.onestop_id,
+      next_feed_version.sha1,
+      import_level
+    )
+    if worker_id
+      puts "  FeedEaterWorker #{worker_id} enqueued"
+    else
+      puts "  FeedEaterWorker: Could not enqueue"
+    end
+  end
+end

--- a/lib/tasks/enqueue_next_feed_version.rake
+++ b/lib/tasks/enqueue_next_feed_version.rake
@@ -1,36 +1,19 @@
 task :enqueue_next_feed_version, [:date] => [:environment] do |t, args|
   date = Date.parse(args.date)
   Feed.find_each do |feed|
-    # Check for active_feed_version
-    active_feed_version = feed.active_feed_version
-    next unless active_feed_version
-    # Find the most recently created feed_version that will have service
-    # on (date) and is newer than the active_feed_version.
-    next_feed_version = feed
-      .feed_versions
-      .where('earliest_calendar_date > ?', active_feed_version.earliest_calendar_date)
-      .where('earliest_calendar_date <= ?', date)
-      .reorder(earliest_calendar_date: :desc, created_at: :desc)
-      .first
-    next unless next_feed_version
-    # Check for any previous import
-    next if next_feed_version.feed_version_imports.last
-    # Enqueue
-    import_level = feed.active_feed_version.import_level || 2
-    puts "Feed: #{feed.onestop_id}"
-    puts "  active_feed_version sha1: #{active_feed_version.sha1}"
-    puts "  active_feed_version date: #{active_feed_version.earliest_calendar_date} - #{active_feed_version.latest_calendar_date}"
-    puts "  next_feed_version   sha1: #{next_feed_version.sha1}"
-    puts "  next_feed_version   date: #{next_feed_version.earliest_calendar_date} - #{next_feed_version.latest_calendar_date}"
-    worker_id = FeedEaterWorker.perform_async(
-      feed.onestop_id,
-      next_feed_version.sha1,
-      import_level
-    )
+    worker_id = feed.enqueue_next_feed_version(date)
     if worker_id
-      puts "  FeedEaterWorker #{worker_id} enqueued"
+      puts "#{feed.onestop_id}: worker #{worker_id} enqueued"
+      active_feed_version = feed.active_feed_version
+      next_feed_version = feed.find_next_feed_version(date)
+      puts "  active #{active_feed_version.sha1}"
+      puts "    calendar  : #{active_feed_version.earliest_calendar_date} - #{active_feed_version.latest_calendar_date}"
+      puts "    created_at: #{active_feed_version.created_at}"
+      puts "  next   #{next_feed_version.sha1}"
+      puts "    calendar  : #{next_feed_version.earliest_calendar_date} - #{next_feed_version.latest_calendar_date}"
+      puts "    created_at: #{next_feed_version.created_at}"
     else
-      puts "  FeedEaterWorker: Could not enqueue"
+      puts "#{feed.onestop_id}: no update"
     end
   end
 end

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -394,4 +394,75 @@ describe Feed do
     end
   end
 
+  context '.find_next_feed_version' do
+    let(:date) { DateTime.now }
+    let(:date_earliest) { date - 2.month }
+    let(:date_earlier) { date - 1.month }
+    let(:date_later) { date + 1.month }
+    let(:feed) { create(:feed) }
+
+    it 'returns nil if no active_feed_version' do
+      expect(feed.find_next_feed_version(DateTime.now)).to be_nil
+    end
+
+    it 'returns nil if active_feed_version is most recent' do
+      fv0 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date)
+      feed.update!(active_feed_version: fv1)
+      expect(feed.find_next_feed_version(DateTime.now)).to be_nil
+    end
+
+    it 'returns nil if earliest_calendar_date is less than active_feed_version' do
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      fv2 = create(:feed_version, feed: feed, earliest_calendar_date: date_earliest)
+      feed.update!(active_feed_version: fv1)
+      expect(feed.find_next_feed_version(date)).to be_nil
+    end
+
+    it 'returns feed_version if same service range but newer than active_feed_version' do
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      fv2 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      feed.update!(active_feed_version: fv1)
+      expect(feed.find_next_feed_version(date)).to eq(fv2)
+    end
+
+    it 'returns feed_version ignoring feed_versions that begin in the future' do
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date_earliest)
+      fv2 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      fv3 = create(:feed_version, feed: feed, earliest_calendar_date: date_later)
+      feed.update!(active_feed_version: fv1)
+      expect(feed.find_next_feed_version(date)).to eq(fv2)
+    end
+
+    it 'returns most recently created feed_version if more than 1 result' do
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date_earliest)
+      fv2 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      fv3 = create(:feed_version, feed: feed, earliest_calendar_date: date_earlier)
+      feed.update!(active_feed_version: fv1)
+      expect(feed.find_next_feed_version(date)).to eq(fv3)
+    end
+  end
+
+  context '.queue_next_feed_version' do
+    let(:date) { DateTime.now }
+    let(:feed) { create(:feed) }
+
+    it 'enqueues next_feed_version' do
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date - 2.months)
+      fv2 = create(:feed_version, feed: feed, earliest_calendar_date: date - 1.months)
+      feed.update!(active_feed_version: fv1)
+      expect {
+        feed.queue_next_feed_version(date)
+      }.to change(FeedEaterWorker.jobs, :size).by(1)
+    end
+
+    it 'does not enqueue if no next_feed_version' do
+      fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date - 2.months)
+      feed.update!(active_feed_version: fv1)
+      expect {
+        feed.queue_next_feed_version(date)
+      }.to change(FeedEaterWorker.jobs, :size).by(0)
+    end
+  end
+
 end

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -450,7 +450,7 @@ describe Feed do
     end
   end
 
-  context '.queue_next_feed_version' do
+  context '.enqueue_next_feed_version' do
     let(:date) { DateTime.now }
     let(:feed) { create(:feed) }
 
@@ -459,7 +459,7 @@ describe Feed do
       fv2 = create(:feed_version, feed: feed, earliest_calendar_date: date - 1.months)
       feed.update!(active_feed_version: fv1)
       expect {
-        feed.queue_next_feed_version(date)
+        feed.enqueue_next_feed_version(date)
       }.to change(FeedEaterWorker.jobs, :size).by(1)
     end
 
@@ -467,7 +467,7 @@ describe Feed do
       fv1 = create(:feed_version, feed: feed, earliest_calendar_date: date - 2.months)
       feed.update!(active_feed_version: fv1)
       expect {
-        feed.queue_next_feed_version(date)
+        feed.enqueue_next_feed_version(date)
       }.to change(FeedEaterWorker.jobs, :size).by(0)
     end
 
@@ -477,7 +477,7 @@ describe Feed do
       create(:feed_version_import, feed_version: fv2)
       feed.update!(active_feed_version: fv1)
       expect {
-        feed.queue_next_feed_version(date)
+        feed.enqueue_next_feed_version(date)
       }.to change(FeedEaterWorker.jobs, :size).by(0)
     end
   end


### PR DESCRIPTION
A rake task.

For each feed:
1. Check that it's been imported successfully at least once
2. Find the most recently created feed_version valid on a given date
3. Make sure the feed_version import hasn't been previously attempted
4. Import with the import_level of the previous active_feed_version
