### PR TITLE
only remove extraneous indexes if they exist

### DIFF
--- a/db/migrate/20160613224412_remove_extraneous_indexes.rb
+++ b/db/migrate/20160613224412_remove_extraneous_indexes.rb
@@ -1,7 +1,32 @@
 class RemoveExtraneousIndexes < ActiveRecord::Migration
-  def change
-    remove_index :current_operators_serving_stop, name: :index_current_operators_serving_stop_on_stop_id
-    remove_index :current_schedule_stop_pairs, name: :index_current_schedule_stop_pairs_on_feed_id
-    remove_index :current_schedule_stop_pairs, name: :index_current_schedule_stop_pairs_on_feed_version_id
+  INDEXES_TO_REMOVE = [
+    {
+      table: :current_operators_serving_stop,
+      column: :stop_id
+    },
+    {
+      table: :current_schedule_stop_pairs,
+      column: :feed_id
+    },
+    {
+      table: :current_schedule_stop_pairs,
+      column: :feed_version_id
+    }
+  ]
+
+  def up
+    INDEXES_TO_REMOVE.each do |hash|
+      if index_exists?(hash[:table], hash[:column])
+        remove_index(hash[:table], column: hash[:column])
+      end
+    end
+  end
+
+  def down
+    INDEXES_TO_REMOVE.each do |hash|
+      unless index_exists?(hash[:table], hash[:column])
+        add_index(hash[:table], hash[:column])
+      end
+    end
   end
 end


### PR DESCRIPTION
This means that indexes can be removed manually from DB, before https://github.com/transitland/transitland-datastore/pull/628 is deployed to production.

related to original issue #626