### PR TITLE
added stops_served_by_route to route controller

### DIFF
--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
     properties[:color] = entity.color
     properties[:operated_by_onestop_id] = entity.operator.try(:onestop_id)
     properties[:operated_by_name] = entity.operator.try(:name)
+    properties[:stops_served_by_route] = entity.stops.map { |stop| {onestop_id: stop.onestop_id, name: stop.name } }
     properties[:route_stop_patterns_by_onestop_id] = entity.route_stop_patterns.map(&:onestop_id)
   }
 

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -62,6 +62,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
 
     @routes = @routes.includes{[
       operator,
+      stops,
       route_stop_patterns,
       imported_from_feeds,
       imported_from_feed_versions

--- a/app/serializers/route_serializer.rb
+++ b/app/serializers/route_serializer.rb
@@ -34,6 +34,7 @@ class RouteSerializer < CurrentEntitySerializer
              :geometry,
              :color,
              :tags,
+             :stops_served_by_route,
              :operated_by_onestop_id,
              :operated_by_name,
              :created_at,
@@ -46,6 +47,10 @@ class RouteSerializer < CurrentEntitySerializer
 
   def operated_by_name
     object.operator.try(:name)
+  end
+
+  def stops_served_by_route
+    object.stops.map { |stop| {onestop_id: stop.onestop_id, name: stop.name } }
   end
 
   def route_stop_patterns_by_onestop_id

--- a/app/serializers/route_serializer.rb
+++ b/app/serializers/route_serializer.rb
@@ -50,7 +50,7 @@ class RouteSerializer < CurrentEntitySerializer
   end
 
   def stops_served_by_route
-    object.stops.map { |stop| {stop_onestop_id: stop.onestop_id, stop_name: stop.name } }
+    object.stops.map { |stop| { stop_onestop_id: stop.onestop_id, stop_name: stop.name } }
   end
 
   def route_stop_patterns_by_onestop_id

--- a/app/serializers/route_serializer.rb
+++ b/app/serializers/route_serializer.rb
@@ -50,7 +50,7 @@ class RouteSerializer < CurrentEntitySerializer
   end
 
   def stops_served_by_route
-    object.stops.map { |stop| {onestop_id: stop.onestop_id, name: stop.name } }
+    object.stops.map { |stop| {stop_onestop_id: stop.onestop_id, stop_name: stop.name } }
   end
 
   def route_stop_patterns_by_onestop_id

--- a/spec/controllers/api/v1/routes_controller_spec.rb
+++ b/spec/controllers/api/v1/routes_controller_spec.rb
@@ -163,14 +163,15 @@ describe Api::V1::RoutesController do
 
   describe 'GET show' do
     context 'as JSON' do
-      it 'returns stops by OnestopID' do
+      it 'returns routes by OnestopID' do
         get :show, id: 'r-9q8y-richmond~dalycity~millbrae'
         expect_json_types({
           onestop_id: :string,
           geometry: :object,
           name: :string,
           created_at: :date,
-          updated_at: :date
+          updated_at: :date,
+          stops_served_by_route: :array
         })
         expect_json({ onestop_id: -> (onestop_id) {
           expect(onestop_id).to eq 'r-9q8y-richmond~dalycity~millbrae'


### PR DESCRIPTION
Routes now return an array of stop onestop id and stop name objects of the stops it serves. Useful for data explorer and probably in general.