### PR TITLE
Compatibility: Stop osm_way_id tag

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -262,7 +262,15 @@ class Stop < BaseStop
           if stop.osm_way_id != osm_way_id
             log "osm_way_id changed for Stop #{stop.onestop_id}: was \"#{stop.osm_way_id}\" now \"#{osm_way_id}\""
           end
-          stop.update(osm_way_id: osm_way_id, last_conflated_at: now)
+          # Copy osm_way_id as a tag for now
+          stop_tags = stop.tags.try(:clone) || {}
+          stop_tags[:osm_way_id] = osm_way_id
+          # Update stop
+          stop.update(
+            osm_way_id: osm_way_id,
+            tags: stop_tags,
+            last_conflated_at: now
+          )
         end
       end
     end

--- a/app/serializers/stop_serializer.rb
+++ b/app/serializers/stop_serializer.rb
@@ -35,6 +35,7 @@ class StopSerializer < CurrentEntitySerializer
              :name,
              :tags,
              :timezone,
+             :osm_way_id,
              :created_at,
              :updated_at
 

--- a/app/serializers/stop_station_serializer.rb
+++ b/app/serializers/stop_station_serializer.rb
@@ -48,6 +48,7 @@ class StopStationSerializer < CurrentEntitySerializer
                :geometry,
                :name,
                :tags,
+               :osm_way_id,
                :created_at,
                :updated_at
                :last_conflated_at


### PR DESCRIPTION
Stop osm_way_id was promoted to an attribute; maintain osm_way_id tag for compatibility until other consumers have been updated.