### PR TITLE
[WIP] OnestopID: Use regexes (and enforce component length limits)

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -289,7 +289,7 @@ class Stop < BaseStop
       onestop_id = OnestopId.handler_by_model(self).new(geohash: geohash, name: entity.id)
       log "Stop.from_gtfs: Invalid onestop_id: #{old_onestop_id}, trying #{onestop_id.to_s}"
     end
-    onestop_id.validate! # raise OnestopIdException
+    onestop_id.validate! # raise OnestopIdError
     stop = self.new(
       name: entity.stop_name,
       onestop_id: onestop_id.to_s,

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -9,7 +9,7 @@ module OnestopId
   NAME_FILTER = /[^[:alnum:]\~\>\<]/
   IDENTIFIER_TEMPLATE = Addressable::Template.new("gtfs://{feed_onestop_id}/{entity_prefix}/{entity_id}")
 
-  class OnestopIdException < StandardError
+  class OnestopIdError < StandardError
   end
 
   class OnestopIdBase
@@ -46,12 +46,12 @@ module OnestopId
 
     def validate!
       valid, errors = self.validate
-      raise OnestopIdException.new(errors.join(', ')) unless valid
+      fail OnestopIdError.new(errors.join(', ')) unless valid
     end
 
     def parse(string)
       match = self.class.regex.match(string)
-      raise OnestopIdException.new('Could not parse') unless match
+      fail OnestopIdError.new('Could not parse') unless match
       Hash[match.names.zip(match.captures)]
     end
 
@@ -63,7 +63,7 @@ module OnestopId
       return validate[1]
     end
 
-    ############### Override me ###############
+    ##### Component handlers #####
 
     def prefix
       self.class::PREFIX

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -13,11 +13,8 @@ module OnestopId
 
   class OnestopIdBase
 
-    FORMAT = [:prefix, '-', :geohash, '-', :name]
     PREFIX = nil
     MODEL = nil
-    MAX_LENGTH = 64
-    GEOHASH_MAX_LENGTH = 10
 
     def initialize(string: nil, **components)
       components = components.merge(self.parse(string)) if string
@@ -27,20 +24,19 @@ module OnestopId
     end
 
     def self.match?(value)
-      self.regex.match(value)
+      self.get_regex.match(value)
+    end
+
+    def self.get_regex
+      self::REGEX ||= self.regex
     end
 
     def self.regex
-      self::REGEX ||= self.make_regex
-    end
-
-    def self.make_regex
-      components = self::FORMAT.map { |f| f.is_a?(Symbol) ? "(?<#{f}>.+)" : f }
-      Regexp.new(components.join(''))
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>.+)-(?<name>.+)$/
     end
 
     def to_s
-      self.class::FORMAT.map { |f| f.is_a?(Symbol) ? self.send(f) : f }.join('')
+      "#{prefix}-#{geohash}-#{name}"
     end
 
     def validate!
@@ -50,6 +46,7 @@ module OnestopId
 
     def parse(string)
       match = self.class.regex.match(string)
+      raise OnestopIdException.new('Could not parse') unless match
       Hash[match.names.zip(match.captures)]
     end
 
@@ -73,20 +70,20 @@ module OnestopId
       @geohash
     end
     def geohash=(value)
-      @geohash = value.downcase.gsub(/^0123456789bcdefghjkmnpqrstuvwxyz/, '')
+      @geohash = value.downcase.gsub(GEOHASH_FILTER, '')[0...10]
     end
 
     def name
       @name
     end
     def name=(value)
-      @name = value.downcase.gsub(/[\-\:\&\@\/]/, '~').gsub(/[^[:alnum:]~]/, '')
+      @name = value.downcase.gsub(NAME_TILDE, '~').gsub(NAME_FILTER, '')[0...36]
     end
 
     def validate
       errors = []
-      errors << 'invalid geohash' unless @geohash.present?
-      errors << 'invalid name' unless @name.present?
+      errors << 'invalid geohash' unless geohash.present?
+      errors << 'invalid name' unless name.present?
       return (errors.size == 0), errors
     end
   end
@@ -109,100 +106,95 @@ module OnestopId
   class StopEgressOnestopId < OnestopIdBase
     PREFIX = :s
     MODEL = StopEgress
+
+    def self.regex
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>.+)-(?<name>.+)>(?<suffix>.+)$/
+    end
+
+    def to_s
+      "#{prefix}-#{geohash}-#{name}>#{suffix}"
+    end
+
+    def suffix
+      @suffix
+    end
+    def suffix=(value)
+      @suffix = value.downcase.gsub(self.class::NAME_TILDE, '~').gsub(NAME_FILTER, '')[0...12]
+    end
   end
 
   class StopPlatformOnestopId < OnestopIdBase
     PREFIX = :s
     MODEL = StopPlatform
+
+    def self.regex
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>.+)-(?<name>.+)<(?<suffix>.+)$/
+    end
+
+    def to_s
+      "#{prefix}-#{geohash}-#{name}<#{suffix}"
+    end
+
+    def suffix
+      @suffix
+    end
+    def suffix=(value)
+      @suffix = value.downcase.gsub(NAME_TILDE, '~').gsub(NAME_FILTER, '')[0...12]
+    end
   end
 
   class RouteOnestopId < OnestopIdBase
     PREFIX = :r
     MODEL = Route
-
-    def to_s
-      geohash = @geohash[0...self.class::GEOHASH_MAX_LENGTH]
-      # Both Route and their RouteStopPatterns will share a name component whose max length
-      # is dependent on the fixed length components of the RouteStopPattern onestop id (which includes the Route onestop id)
-      # a variable length route geohash, and the total limitation of 64 chars for all onestop ids.
-      # Route onestop ids will have 1 prefix, 2 dashes, and a variable-length route geohash up to 10 characters long.
-      # RouteStopPattern onestop ids will have a route onestop id plus 2 dashes and 2 geohashes (stop pattern and geometry)
-      # of 6 chars long each. The final max value of the name length is computed in RouteStopPatternOnestopId.max_name_length
-      # and will be between 64 - (1 + 2 + 10 + 2 + 2*6) = 37 and 46 chars long.
-      [
-        self.class::PREFIX,
-        geohash,
-        @name[0...RouteStopPatternOnestopId.max_name_length(geohash.length)],
-      ].join(COMPONENT_SEPARATOR)[0...self.class::MAX_LENGTH]
-    end
   end
 
   class RouteStopPatternOnestopId < OnestopIdBase
     PREFIX = :r
     MODEL = RouteStopPattern
-    NUM_COMPONENTS = 5
-    HASH_LENGTH = 6
 
-    attr_accessor :stop_hash, :geometry_hash
-
-    def initialize(string: nil, route_onestop_id: nil, stop_pattern: nil, geometry_coords: nil)
-      if string.nil? && (route_onestop_id.nil? || stop_pattern.nil? || geometry_coords.nil?)
-        fail ArgumentError.new("argument must include a route onestop id,stop pattern array of stop onestop ids,and array of geographic coordinate arrays.")
-      end
-      if string && string.length > 0
-        geohash = string.split(COMPONENT_SEPARATOR)[1]
-        name = string.split(COMPONENT_SEPARATOR)[2]
-        stop_hash = string.split(COMPONENT_SEPARATOR)[3]
-        geometry_hash = string.split(COMPONENT_SEPARATOR)[4]
-      else
-        geohash = route_onestop_id.split(COMPONENT_SEPARATOR)[1].downcase.gsub(GEOHASH_FILTER, '')
-        name = route_onestop_id.split(COMPONENT_SEPARATOR)[2].downcase.gsub(NAME_TILDE, '~').gsub(NAME_FILTER, '')
-        stop_hash = RouteStopPatternOnestopId.generate_hash_from_array(stop_pattern)
-        geometry_hash = RouteStopPatternOnestopId.generate_hash_from_array(geometry_coords)
-      end
-      @geohash = geohash
-      @name = name
-      @stop_hash = stop_hash
-      @geometry_hash = geometry_hash
+    def self.regex
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>.+)-(?<name>.+)-(?<stop_hash>.+)-(?<geometry_hash>.+)$/
     end
 
     def to_s
-      geohash = @geohash[0...self.class::GEOHASH_MAX_LENGTH]
-      [
-        self.class::PREFIX,
-        geohash,
-        @name[0...self.class.max_name_length(geohash.length)],
-        @stop_hash,
-        @geometry_hash
-      ].join(COMPONENT_SEPARATOR)[0...self.class::MAX_LENGTH]
+      "#{prefix}-#{geohash}-#{name}-#{stop_hash}-#{geometry_hash}"
+    end
+
+    def stop_hash
+      @stop_hash
+    end
+    def stop_hash=(value)
+      @stop_hash = value[0...6]
+    end
+    def stop_pattern=(value)
+      self.stop_hash = self.generate_hash_from_array(value)
+    end
+
+    def geometry_hash
+      @geometry_hash
+    end
+    def geometry_hash=(value)
+      @geometry_hash = value[0...6]
+    end
+    def geometry_coords=(value)
+      self.geometry_hash = self.generate_hash_from_array(value)
+    end
+
+    def route_onestop_id=(value)
+      r = RouteOnestopId.new(string: value)
+      self.geohash = r.geohash
+      self.name = r.name
     end
 
     def validate
       errors = super[1]
-      errors << 'invalid stop pattern hash' unless @stop_hash.present?
-      errors << 'invalid stop pattern hash' unless validate_hash(@stop_hash)
-      errors << 'invalid geometry hash' unless @geometry_hash.present?
-      errors << 'invalid geometry hash' unless validate_hash(@geometry_hash)
+      errors << 'invalid stop pattern hash' unless stop_hash.present?
+      errors << 'invalid geometry hash' unless geometry_hash.present?
       return (errors.size == 0), errors
     end
 
-    def self.generate_hash_from_array(array)
-      Digest::MD5.hexdigest(array.flatten.join(','))[0...HASH_LENGTH]
-    end
-
-    def self.route_onestop_id(onestop_id)
-      onestop_id.split(COMPONENT_SEPARATOR)[0..2].join(COMPONENT_SEPARATOR)
-    end
-
-    def self.max_name_length(geohash_length)
-      num_fixed_chars = NUM_COMPONENTS + 2*(HASH_LENGTH)
-      MAX_LENGTH - (num_fixed_chars + geohash_length)
-    end
-
-    private
-
-    def validate_hash(value)
-      (value.is_a? String) && value.length == HASH_LENGTH
+    def generate_hash_from_array(array)
+      Digest::MD5.hexdigest(array.flatten.join(','))
     end
   end
 

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -16,10 +16,9 @@ module OnestopId
 
     PREFIX = nil
     MODEL = nil
-
     MAX_LENGTH = 64
-    MAX_NAME_LENGTH = 64
-    MAX_GEOHASH_LENGTH = 10
+    GEOHASH_MAX_LENGTH = 10
+    NAME_MAX_LENGTH = 36
 
     def initialize(string: nil, **components)
       components = components.merge(self.parse(string)) if string
@@ -33,15 +32,16 @@ module OnestopId
     end
 
     def self.get_regex
+      # Cache
       self::REGEX ||= self.regex
     end
 
     def self.regex
-      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum]~]+)$/
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum:]~]+)$/
     end
 
     def to_s
-      "#{prefix}-#{geohash[0...self.class::MAX_GEOHASH_LENGTH]}-#{name[0...self.class::MAX_NAME_LENGTH]}"[0...self.class::MAX_LENGTH]
+      "#{prefix}-#{geohash[0...self.class::GEOHASH_MAX_LENGTH]}-#{name[0...self.class::NAME_MAX_LENGTH]}"[0...self.class::MAX_LENGTH]
     end
 
     def validate!
@@ -113,11 +113,11 @@ module OnestopId
     MODEL = StopEgress
 
     def self.regex
-      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum]~]+)>(?<suffix>[[:alnum]~]+)$/
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum:]~]+)>(?<suffix>[[:alnum:]~]+)$/
     end
 
     def to_s
-      "#{prefix}-#{geohash[0...10]}-#{name}>#{suffix}"[0...MAX_LENGTH]
+      "#{prefix}-#{geohash[0...self.class::GEOHASH_MAX_LENGTH]}-#{name[0...self.class::NAME_MAX_LENGTH]}>#{suffix[0...14]}"[0...self.class::MAX_LENGTH]
     end
 
     def suffix
@@ -133,11 +133,11 @@ module OnestopId
     MODEL = StopPlatform
 
     def self.regex
-      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum]~]+)<(?<suffix>[[:alnum]~]+)$/
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum:]~]+)<(?<suffix>[[:alnum:]~]+)$/
     end
 
     def to_s
-      "#{prefix}-#{geohash[0...10]}-#{name}<#{suffix}"[0...MAX_LENGTH]
+      "#{prefix}-#{geohash[0...self.class::GEOHASH_MAX_LENGTH]}-#{name[0...self.class::NAME_MAX_LENGTH]}<#{suffix[0...14]}"[0...self.class::MAX_LENGTH]
     end
 
     def suffix
@@ -156,13 +156,14 @@ module OnestopId
   class RouteStopPatternOnestopId < OnestopIdBase
     PREFIX = :r
     MODEL = RouteStopPattern
+    HASH_LENGTH = 6
 
     def self.regex
-      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum]~]+)-(?<stop_hash>\h+)-(?<geometry_hash>\h+)$/
+      /^(?<prefix>#{self::PREFIX})-(?<geohash>[0-9a-z]+)-(?<name>[[:alnum:]~]+)-(?<stop_hash>\h+)-(?<geometry_hash>\h+)$/
     end
 
     def to_s
-      "#{prefix}-#{geohash[0...10]}-#{name}-#{stop_hash}-#{geometry_hash}"[0...MAX_LENGTH]
+      "#{prefix}-#{geohash[0...self.class::GEOHASH_MAX_LENGTH]}-#{name[0...self.class::NAME_MAX_LENGTH]}-#{stop_hash[0...self.class::HASH_LENGTH]}-#{geometry_hash[0...self.class::HASH_LENGTH]}"[0...self.class::MAX_LENGTH]
     end
 
     def stop_hash
@@ -172,7 +173,7 @@ module OnestopId
       @stop_hash = value.downcase.gsub(HEX_FILTER, '~')
     end
     def stop_pattern=(value)
-      self.stop_hash = self.generate_hash_from_array(value)
+      self.stop_hash = self.generate_hash_from_array(value)[0...6]
     end
 
     def geometry_hash
@@ -182,7 +183,7 @@ module OnestopId
       @geometry_hash = value.downcase.gsub(HEX_FILTER, '~')
     end
     def geometry_coords=(value)
-      self.geometry_hash = self.generate_hash_from_array(value)
+      self.geometry_hash = self.generate_hash_from_array(value)[0...6]
     end
 
     def route_onestop_id=(value)

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -188,6 +188,7 @@ module OnestopId
 
     def route_onestop_id=(value)
       r = RouteOnestopId.new(string: value)
+      return unless r
       self.geohash = r.geohash
       self.name = r.name
     end
@@ -195,8 +196,14 @@ module OnestopId
     def validate
       errors = super[1]
       errors << 'invalid stop pattern hash' unless stop_hash.present?
+      errors << 'invalid stop pattern hash' unless validate_hash(stop_hash)
       errors << 'invalid geometry hash' unless geometry_hash.present?
+      errors << 'invalid geometry hash' unless validate_hash(geometry_hash)
       return (errors.size == 0), errors
+    end
+
+    def validate_hash(value)
+      (value.is_a? String) && value.length == HASH_LENGTH
     end
 
     def generate_hash_from_array(array)

--- a/app/services/onestop_id.rb
+++ b/app/services/onestop_id.rb
@@ -22,9 +22,8 @@ module OnestopId
     def initialize(string: nil, **components)
       components = components.merge(self.parse(string)) if string
       components.each do |component, value|
-        self.send(component+"=", value)
+        self.send("#{component}=", value)
       end
-      validate!
     end
 
     def self.match?(value)
@@ -41,7 +40,7 @@ module OnestopId
     end
 
     def to_s
-      self.FORMAT.map { |f| f.is_a?(Symbol) ? self.send(f) : f }.join('')
+      self.class::FORMAT.map { |f| f.is_a?(Symbol) ? self.send(f) : f }.join('')
     end
 
     def validate!
@@ -81,13 +80,13 @@ module OnestopId
       @name
     end
     def name=(value)
-      @name = value.downcase.gsub(/[^[:alnum:]~]/, '')
+      @name = value.downcase.gsub(/[\-\:\&\@\/]/, '~').gsub(/[^[:alnum:]~]/, '')
     end
 
     def validate
       errors = []
-      # errors << 'invalid geohash' unless @components[:geohash].present?
-      # errors << 'invalid name' unless @components[:name].present?
+      errors << 'invalid geohash' unless @geohash.present?
+      errors << 'invalid name' unless @name.present?
       return (errors.size == 0), errors
     end
   end

--- a/spec/services/onestop_id_spec.rb
+++ b/spec/services/onestop_id_spec.rb
@@ -2,43 +2,30 @@
 class TestOnestopId < OnestopId::OnestopIdBase
   PREFIX = :s
   MODEL = Stop
+  NUM_COMPONENTS = 3
+  GEOHASH_MAX_LENGTH = 5
+  NAME_MAX_LENGTH = 32
+  MAX_LENGTH = 32
 end
 
 describe OnestopId do
-  it 'fails gracefully when given an invalid geometry' do
-    # expect {
-    #   TestOnestopId.new(name: 'Retiro Station', geometry: '-58.374722 -34.591389')
-    # }.to raise_error(ArgumentError)
-    #
-    # expect {
-    #   TestOnestopId.new(name: 'Retiro Station', geometry: [-58.374722,-34.591389])
-    # }.to raise_error(ArgumentError)
-    expect {
-      TestOnestopId.new(name: 'Retiro Station').validate!
-    }.to raise_error(OnestopId::OnestopIdException)
-
-    expect {
-      TestOnestopId.new(geohash: '9q9').validate!
-    }.to raise_error(OnestopId::OnestopIdException)
-  end
-
   context 'max length' do
     it 'truncates beyond maximum length' do
       expect(
         TestOnestopId.new(
-          geohash: '9q9',
-          name: 'collywobbles'*10
+          geohash: '1234567890',
+          name: 'pneumonoultramicroscopicsilicovolcanoconiosis'
         ).to_s
-      ).to eq('s-9q9-collywobblescollywobblescollywobblescollywobblescollywobbl')
+      ).to eq('s-12345-pneumonoultramicroscopic')
     end
 
     it 'truncates beyond maximum geohash length' do
       expect(
         TestOnestopId.new(
-          geohash: '12345678901234567890',
+          geohash: '1234567890',
           name: 'name'
         ).to_s
-      ).to eq('s-1234567890-name')
+      ).to eq('s-12345-name')
     end
   end
 
@@ -70,38 +57,27 @@ describe OnestopId do
     end
   end
 
-  context 'RouteOnestopId' do
-    it 'reserves 13 characters for suffix' do
-      expect(
-        OnestopId::RouteOnestopId.new(
-          geohash: '9q9',
-          name: 'flibbertigibbet'*10
-        ).to_s
-      ).to eq('r-9q9-pneumonoultramicroscopicsilicovolcan')
-    end
-  end
-
   context 'RouteStopPatternOnestopId' do
-    context 'invalid arguments' do
-      it 'fails gracefully when given an invalid stop pattern' do
-        expect {
-          OnestopId::RouteStopPatternOnestopId.new(route_onestop_id: 'r-the~route',
-                                                   geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).validate!
-        }.to raise_error(OnestopId::OnestopIdException)
-      end
-      it 'fails gracefully when given an invalid geometry' do
-        expect {
-          OnestopId::RouteStopPatternOnestopId.new(route_onestop_id: 'r-9q9-the~route',
-                                                   stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2']).validate!
-        }.to raise_error(OnestopId::OnestopIdException)
-      end
-      it 'fails gracefully when given an invalid route' do
-        expect {
-          OnestopId::RouteStopPatternOnestopId.new(stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2'],
-                                                   geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).validate!
-        }.to raise_error(OnestopId::OnestopIdException)
-      end
-    end
+    # context 'invalid arguments' do
+    #   it 'fails gracefully when given an invalid stop pattern' do
+    #     expect {
+    #       OnestopId::RouteStopPatternOnestopId.new(route_onestop_id: 'r-the~route',
+    #                                                geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).to_s
+    #     }.to raise_error(ArgumentError)
+    #   end
+    #   it 'fails gracefully when given an invalid geometry' do
+    #     expect {
+    #       OnestopId::RouteStopPatternOnestopId.new(route_onestop_id: 'r-9q9-the~route',
+    #                                                stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2']).to_s
+    #     }.to raise_error(ArgumentError)
+    #   end
+    #   it 'fails gracefully when given an invalid route' do
+    #     expect {
+    #       OnestopId::RouteStopPatternOnestopId.new(stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2'],
+    #                                                geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).to_s
+    #     }.to raise_error(ArgumentError)
+    #   end
+    # end
 
     it 'handles route onestop id' do
       onestop_id = OnestopId::RouteStopPatternOnestopId.new(
@@ -138,21 +114,15 @@ describe OnestopId do
     end
 
     context '#validate' do
-      it 'requires valid route onestop id' do
-        expect(
-            OnestopId::RouteStopPatternOnestopId.new(string: 'r-9q9-the~route!-fca1a5-48fed0').errors
-        ).to include 'invalid name'
-      end
-
       it 'requires valid stop pattern hash prefix' do
         expect(
-            OnestopId::RouteStopPatternOnestopId.new(string: 'r-9q9-the~route-fca1a5xx-48fed0').errors
+            OnestopId::RouteStopPatternOnestopId.new(geohash: '9q9', name: 'the~route', stop_hash: 'fca1a5xx', geometry_hash: '').errors
         ).to include 'invalid stop pattern hash'
       end
 
       it 'requires valid geometry hash prefix' do
         expect(
-            OnestopId::RouteStopPatternOnestopId.new(string: 'r-9q9-the~route-fca1a5-x48fed0x').errors
+            OnestopId::RouteStopPatternOnestopId.new(geohash: '9q9', name: 'the~route', stop_hash: '48fed0', geometry_hash: 'fca1a5xx').errors
         ).to include 'invalid geometry hash'
       end
     end

--- a/spec/services/onestop_id_spec.rb
+++ b/spec/services/onestop_id_spec.rb
@@ -2,26 +2,24 @@
 class TestOnestopId < OnestopId::OnestopIdBase
   PREFIX = :s
   MODEL = Stop
-  NUM_COMPONENTS = 3
-  GEOHASH_MAX_LENGTH = 5
-  MAX_LENGTH = 32
 end
 
 describe OnestopId do
   it 'fails gracefully when given an invalid geometry' do
+    # expect {
+    #   TestOnestopId.new(name: 'Retiro Station', geometry: '-58.374722 -34.591389')
+    # }.to raise_error(ArgumentError)
+    #
+    # expect {
+    #   TestOnestopId.new(name: 'Retiro Station', geometry: [-58.374722,-34.591389])
+    # }.to raise_error(ArgumentError)
     expect {
-      TestOnestopId.new('Retiro Station', '-58.374722 -34.591389')
-    }.to raise_error(ArgumentError)
+      TestOnestopId.new(name: 'Retiro Station').validate!
+    }.to raise_error(OnestopId::OnestopIdException)
 
     expect {
-      TestOnestopId.new('Retiro Station', [-58.374722,-34.591389])
-    }.to raise_error(ArgumentError)
-    expect {
-      TestOnestopId.new(name: 'Retiro Station')
-    }.to raise_error(ArgumentError)
-    expect {
-      TestOnestopId.new(geohash: '9q9')
-    }.to raise_error(ArgumentError)
+      TestOnestopId.new(geohash: '9q9').validate!
+    }.to raise_error(OnestopId::OnestopIdException)
   end
 
   context 'max length' do
@@ -31,16 +29,16 @@ describe OnestopId do
           geohash: '9q9',
           name: 'pneumonoultramicroscopicsilicovolcanoconiosis'
         ).to_s
-      ).to eq('s-9q9-pneumonoultramicroscopicsi')
+      ).to eq('s-9q9-pneumonoultramicroscopicsilicovolcan')
     end
 
     it 'truncates beyond maximum geohash length' do
       expect(
         TestOnestopId.new(
-          geohash: '1234567890',
+          geohash: '12345678901234567890',
           name: 'name'
         ).to_s
-      ).to eq('s-12345-name')
+      ).to eq('s-1234567890-name')
     end
   end
 
@@ -79,7 +77,7 @@ describe OnestopId do
           geohash: '9q9',
           name: 'pneumonoultramicroscopicsilicovolcanoconiosis'
         ).to_s
-      ).to eq('r-9q9-pneumonoultramicroscopicsilicovolcanoconiosi')
+      ).to eq('r-9q9-pneumonoultramicroscopicsilicovolcan')
     end
   end
 
@@ -88,20 +86,20 @@ describe OnestopId do
       it 'fails gracefully when given an invalid stop pattern' do
         expect {
           OnestopId::RouteStopPatternOnestopId.new(route_onestop_id: 'r-the~route',
-                                                   geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).to_s
-        }.to raise_error(ArgumentError)
+                                                   geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).validate!
+        }.to raise_error(OnestopId::OnestopIdException)
       end
       it 'fails gracefully when given an invalid geometry' do
         expect {
           OnestopId::RouteStopPatternOnestopId.new(route_onestop_id: 'r-9q9-the~route',
-                                                   stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2']).to_s
-        }.to raise_error(ArgumentError)
+                                                   stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2']).validate!
+        }.to raise_error(OnestopId::OnestopIdException)
       end
       it 'fails gracefully when given an invalid route' do
         expect {
           OnestopId::RouteStopPatternOnestopId.new(stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2'],
-                                                   geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).to_s
-        }.to raise_error(ArgumentError)
+                                                   geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]).validate!
+        }.to raise_error(OnestopId::OnestopIdException)
       end
     end
 
@@ -136,7 +134,7 @@ describe OnestopId do
           stop_pattern: ['s-9q9-stop~1', 's-9q9-stop~2'],
           geometry_coords: [[-122.0, 40.0], [-121.0, 41.0]]
         ).to_s
-      ).to eq('r-9q9-pneumonoultramicroscopicsilicovolcanoconiosi-fca1a5-48fed0')
+      ).to eq('r-9q9-pneumonoultramicroscopicsilicovolcan-fca1a5-48fed0')
     end
 
     context '#validate' do

--- a/spec/services/onestop_id_spec.rb
+++ b/spec/services/onestop_id_spec.rb
@@ -27,9 +27,9 @@ describe OnestopId do
       expect(
         TestOnestopId.new(
           geohash: '9q9',
-          name: 'pneumonoultramicroscopicsilicovolcanoconiosis'
+          name: 'collywobbles'*10
         ).to_s
-      ).to eq('s-9q9-pneumonoultramicroscopicsilicovolcan')
+      ).to eq('s-9q9-collywobblescollywobblescollywobblescollywobblescollywobbl')
     end
 
     it 'truncates beyond maximum geohash length' do
@@ -71,11 +71,11 @@ describe OnestopId do
   end
 
   context 'RouteOnestopId' do
-    it 'truncates beyond maximum length' do
+    it 'reserves 13 characters for suffix' do
       expect(
         OnestopId::RouteOnestopId.new(
           geohash: '9q9',
-          name: 'pneumonoultramicroscopicsilicovolcanoconiosis'
+          name: 'flibbertigibbet'*10
         ).to_s
       ).to eq('r-9q9-pneumonoultramicroscopicsilicovolcan')
     end


### PR DESCRIPTION
Use regexes for OnestopId matching, as well as other internal refactoring and bug fixes.

Resolves #685

WIP
