### PR TITLE
Stop OnestopID: Filter special characters

### DIFF
--- a/app/models/stop.rb
+++ b/app/models/stop.rb
@@ -283,7 +283,7 @@ class Stop < BaseStop
     point = Stop::GEOFACTORY.point(*entity.coordinates)
     geohash = GeohashHelpers.encode(point)
     # Use stop_id as a fallback for an invalid onestop ID name component
-    onestop_id = OnestopId.handler_by_model(self).new(geohash: geohash, name: entity.stop_name)
+    onestop_id = OnestopId.handler_by_model(self).new(geohash: geohash, name: entity.stop_name.gsub(/[\>\<]/, ''))
     if onestop_id.valid? == false
       old_onestop_id = onestop_id.to_s
       onestop_id = OnestopId.handler_by_model(self).new(geohash: geohash, name: entity.id)


### PR DESCRIPTION
Quick fix for Siena Mobilità and Everett Transit.

Better fix coming in #700.

Resolves #685 
Resolves https://github.com/transitland/transitland/issues/69
