### PR TITLE
GTFSGraph: Skip agencies without stops

### DIFF
--- a/app/services/geohash_helpers.rb
+++ b/app/services/geohash_helpers.rb
@@ -1,18 +1,18 @@
 module GeohashHelpers
   GEOFACTORY = RGeo::Geographic.simple_mercator_factory
-  BASESEQUENCE = '0123456789bcdefghjkmnpqrstuvwxyz'    
+  BASESEQUENCE = '0123456789bcdefghjkmnpqrstuvwxyz'
 
   def self.encode(geometry, precision=10)
     # Encode a RGeo point to a geohash.
     GeoHash.encode(geometry.lat, geometry.lon, precision)
   end
-    
+
   def self.decode(geohash, decimals=5)
     # Decode a geohash to an RGeo point.
     p = GeoHash.decode(geohash, decimals)
     GEOFACTORY.point(p[1], p[0])
   end
-  
+
   def self.decode_bbox(geohash)
     # Decode a geohash to an RGeo bounding box.
     p = GeoHash.decode_bbox(geohash)
@@ -21,7 +21,7 @@ module GeohashHelpers
       GEOFACTORY.point(p[1][1], p[1][0])
     )
   end
-  
+
   def self.adjacent(geohash, direction)
     # Return the neighboring geohash in a given n,s,e,w direction.
     # Based on an MIT licensed implementation by Chris Veness from:
@@ -49,7 +49,7 @@ module GeohashHelpers
     end
     parent + BASESEQUENCE[neighbor[direction][t].index(last)]
   end
-  
+
   def self.neighbors(geohash)
     {
       n:  adjacent(geohash, :n),
@@ -72,17 +72,18 @@ module GeohashHelpers
       decode_bbox(neighborhood[:sw]).min_point
     )
   end
-  
+
   def self.centroid(geometries)
     # Simple geometric average of geometries
     GEOFACTORY.point(
       geometries.map { |x| x.lon }.sum / geometries.size,
-      geometries.map { |x| x.lat }.sum / geometries.size,      
+      geometries.map { |x| x.lat }.sum / geometries.size,
     )
   end
-  
+
   def self.fit(geometries)
     # Fit a collection of points inside a geohash+neighbors
+    raise ArgumentError.new('Need at least 1 geometry') if geometries.size == 0
     start = encode(centroid(geometries))
     geohashes = geometries.map { |x| encode(x) }
     for i in 1..(start.length-1) do
@@ -93,7 +94,7 @@ module GeohashHelpers
         break
       end
     end
-    g[0..-2]    
+    g[0..-2]
   end
-    
+
 end

--- a/app/services/geohash_helpers.rb
+++ b/app/services/geohash_helpers.rb
@@ -83,6 +83,7 @@ module GeohashHelpers
 
   def self.fit(geometries)
     # Fit a collection of points inside a geohash+neighbors
+    geometries ||= []
     raise ArgumentError.new('Need at least 1 geometry') if geometries.size == 0
     start = encode(centroid(geometries))
     geohashes = geometries.map { |x| encode(x) }

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -307,7 +307,15 @@ class GTFSGraph
     @feed.operators_in_feed.each do |oif|
       entity = agencies[oif.gtfs_agency_id]
       # Skip Operator if not found
-      next unless entity
+      if entity.nil?
+        graph_log "    #{oif.operator.onestop_id}: Skipping, GTFS agency_id #{oif.gtfs_agency_id} not found."
+        next
+      end
+      # Skip if no stops
+      if entity.stops.empty?
+        graph_log "    #{oif.operator.onestop_id}: Skipping, GTFS agency_id #{oif.gtfs_agency_id} has no stops."
+        next
+      end
       # Create Operator from GTFS
       operator = Operator.from_gtfs(entity)
       operator.onestop_id = oif.operator.onestop_id # Override Onestop ID

--- a/spec/services/geohash_helpers_spec.rb
+++ b/spec/services/geohash_helpers_spec.rb
@@ -54,7 +54,7 @@ describe GeohashHelpers do
       [-122.434092, 37.732921]
     ].map { |lon,lat| GEOFACTORY.point(lon, lat)}
   }
-  
+
   it 'encode' do
     expect(GeohashHelpers.encode(test_point, precision=test_geohash.length)).to eq(test_geohash)
   end
@@ -69,9 +69,9 @@ describe GeohashHelpers do
     expect(GeohashHelpers.adjacent('9p', :e)).to eq('9r')
     expect(GeohashHelpers.adjacent('9p', :s)).to eq('9n')
     expect(GeohashHelpers.adjacent('9p', :w)).to eq('8z')
-    expect(GeohashHelpers.adjacent('9p', :n)).to eq('c0')    
+    expect(GeohashHelpers.adjacent('9p', :n)).to eq('c0')
   end
-  
+
   it 'adjacent requires valid direction' do
     expect {
       GeohashHelpers.adjacent('9p', :x)
@@ -99,7 +99,16 @@ describe GeohashHelpers do
   it 'fit' do
     expect(GeohashHelpers.fit(test_geometries)).to eq('9q9')
   end
-  
+
+  it 'fit works with a single geometry' do
+    expect(GeohashHelpers.fit(test_geometries.take(1))).to eq('9q9p9h03')
+  end
+
+
+  it 'fit fails with no geometries' do
+    expect { GeohashHelpers.fit([]) }.to raise_error(ArgumentError)
+  end
+
   it 'neighbors_bbox' do
     # geohash 9q9
     bbox = GeohashHelpers.neighbors_bbox('9q9')
@@ -110,7 +119,7 @@ describe GeohashHelpers do
     expect(bbox.max_point).to eq(max_point)
     expect(bbox.min_point).to eq(min_point)
     expect(bbox.contains?(max_point)).to be true
-    expect(bbox.contains?(min_point)).to be true    
+    expect(bbox.contains?(min_point)).to be true
   end
-  
+
 end


### PR DESCRIPTION
GeohashHelpers.fit needs at least 1 geometry; skip agencies without at least stop (similar to routes).

Resolves https://github.com/transitland/transitland/issues/73