### PR TITLE
Entity: where_imported_from_active_feed_version

### DIFF
--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -119,7 +119,7 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
 
     # Explicitly use active Feed Versions
     if params[:active].presence == 'true'
-      @ssps = @ssps.where_active
+      @ssps = @ssps.where_imported_from_active_feed_version
     end
     # Feed
     feed_onestop_id = params[:feed_onestop_id].presence || params[:imported_from_feed].presence

--- a/app/models/concerns/is_an_entity_imported_from_feeds.rb
+++ b/app/models/concerns/is_an_entity_imported_from_feeds.rb
@@ -25,5 +25,13 @@ module IsAnEntityImportedFromFeeds
         })
         .distinct
     }
+
+    scope :where_inactive, -> {
+      active_feed_version_ids = FeedVersion.where_active.select(:id).distinct.pluck(:id)
+      referenced_ids = EntityImportedFromFeed.where(entity_type: self, feed_version_id: active_feed_version_ids).select(:entity_id).distinct.pluck(:entity_id)
+      all_ids = self.select(:id).pluck(:id)
+      where(id: (all_ids - referenced_ids))
+    }
+
   end
 end

--- a/app/models/concerns/is_an_entity_imported_from_feeds.rb
+++ b/app/models/concerns/is_an_entity_imported_from_feeds.rb
@@ -26,11 +26,15 @@ module IsAnEntityImportedFromFeeds
         .distinct
     }
 
+    scope :where_active, -> {
+      joins(:entities_imported_from_feed)
+        .joins('INNER JOIN current_feeds ON entities_imported_from_feed.feed_version_id = current_feeds.active_feed_version_id')
+        .distinct
+    }
+
     scope :where_inactive, -> {
-      active_feed_version_ids = FeedVersion.where_active.select(:id).distinct.pluck(:id)
-      referenced_ids = EntityImportedFromFeed.where(entity_type: self, feed_version_id: active_feed_version_ids).select(:entity_id).distinct.pluck(:entity_id)
-      all_ids = self.select(:id).pluck(:id)
-      where(id: (all_ids - referenced_ids))
+      # This may be possible with a complex outer join, but this will do.
+      where(id: Stop.all.select(:id).pluck(:id) - Stop.where_active.select(:id).pluck(:id))
     }
 
   end

--- a/app/models/concerns/is_an_entity_imported_from_feeds.rb
+++ b/app/models/concerns/is_an_entity_imported_from_feeds.rb
@@ -26,15 +26,15 @@ module IsAnEntityImportedFromFeeds
         .distinct
     }
 
-    scope :where_active, -> {
+    scope :where_imported_from_active_feed_version, -> {
       joins(:entities_imported_from_feed)
         .joins('INNER JOIN current_feeds ON entities_imported_from_feed.feed_version_id = current_feeds.active_feed_version_id')
         .distinct
     }
 
-    scope :where_inactive, -> {
+    scope :where_not_imported_from_active_feed_version, -> {
       # This may be possible with a complex outer join, but this will do.
-      where(id: Stop.all.select(:id).pluck(:id) - Stop.where_active.select(:id).pluck(:id))
+      where(id: self.all.select(:id).pluck(:id) - self.where_imported_from_active_feed_version.select(:id).pluck(:id))
     }
 
   end

--- a/app/models/schedule_stop_pair.rb
+++ b/app/models/schedule_stop_pair.rb
@@ -123,7 +123,7 @@ class ScheduleStopPair < BaseScheduleStopPair
   }
 
   # Active Feed Version
-  scope :where_active, -> {
+  scope :where_imported_from_active_feed_version, -> {
     joins('INNER JOIN current_feeds ON feed_version_id = current_feeds.active_feed_version_id')
   }
 

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -7,7 +7,7 @@ namespace :db do
       puts mode == 0 ? "logging mode" : "delete mode"
       begin
         [Stop,Route,RouteStopPattern].each do |entity|
-          entities_inactive = entity.where_inactive
+          entities_inactive = entity.where_not_imported_from_active_feed_version
           puts "Found #{entities_inactive.count} #{entity.to_s}s to delete."
 
           entities_inactive.find_in_batches do |entities_to_delete|
@@ -36,7 +36,7 @@ namespace :db do
                 route_serving_stops.delete_all
               end
             end
-            
+
             if (entity == Stop)
               operator_serving_stops = OperatorServingStop.where(stop_id: entities_to_delete)
               puts "Found #{operator_serving_stops.size} OperatorServingStops to delete."

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -20,9 +20,9 @@ namespace :db do
             end
 
             # Delete EIFFs
-            entities_imported = EntityImportedFromFeed.where(entity_id: entities_to_delete, entity_type: entity.to_s)
+            entities_imported = EntityImportedFromFeed.where(entity_id: entities_to_delete, entity_type: entity)
             puts "Found #{entities_imported.size} EntityImportedFromFeed #{entity.to_s}s to delete."
-            if (mode == 1 && !entities_imported.empty?)
+            if (mode == 1)
               puts "Deleting unreferenced EntityImportedFromFeed #{entity.to_s}s."
               entities_imported.delete_all
             end
@@ -31,20 +31,21 @@ namespace :db do
             if (entity == Route)
               route_serving_stops = RouteServingStop.where(route_id: entities_to_delete)
               puts "Found #{route_serving_stops.size} RouteServingStops to delete."
-              if (mode == 1 && !route_serving_stops.empty?)
+              if (mode == 1)
                 puts "Deleting unreferenced RouteServingStops."
                 route_serving_stops.delete_all
               end
             end
-
+            
             if (entity == Stop)
               operator_serving_stops = OperatorServingStop.where(stop_id: entities_to_delete)
               puts "Found #{operator_serving_stops.size} OperatorServingStops to delete."
-              if (mode == 1 && !operator_serving_stops.empty?)
+              if (mode == 1)
                 puts "Deleting unreferenced OperatorServingStops."
                 operator_serving_stops.delete_all
               end
             end
+
           end
         end
       rescue

--- a/lib/tasks/db_cleanup.rake
+++ b/lib/tasks/db_cleanup.rake
@@ -7,35 +7,44 @@ namespace :db do
       puts mode == 0 ? "logging mode" : "delete mode"
       begin
         [Stop,Route,RouteStopPattern].each do |entity|
-          entities_to_delete = entity.where('').reject { |e| e.imported_from_feed_versions.any?(&:is_active_feed_version) }
-          entities_to_delete_ids = entities_to_delete.map(&:id)
-          if (entity == Route)
-            route_serving_stops = RouteServingStop.where(route_id: entities_to_delete_ids)
-            puts "Found #{route_serving_stops.size} RouteServingStops to delete."
-            if (mode == 1 && !route_serving_stops.empty?)
-              puts "Deleting unreferenced RouteServingStops."
-              route_serving_stops.delete_all
+          entities_inactive = entity.where_inactive
+          puts "Found #{entities_inactive.count} #{entity.to_s}s to delete."
+
+          entities_inactive.find_in_batches do |entities_to_delete|
+
+            # Delete entities
+            entities_to_delete.each { |e| puts " #{entity.to_s}: #{e.onestop_id}" }
+            if (mode == 1)
+              puts "Deleting unreferenced #{entity.to_s}s."
+              entities_to_delete.each { |e| e.delete }
             end
-          end
-          if (entity == Stop)
-            operator_serving_stops = OperatorServingStop.where(stop_id: entities_to_delete_ids)
-            puts "Found #{operator_serving_stops.size} OperatorServingStops to delete."
-            if (mode == 1 && !operator_serving_stops.empty?)
-              puts "Deleting unreferenced OperatorServingStops."
-              operator_serving_stops.delete_all
+
+            # Delete EIFFs
+            entities_imported = EntityImportedFromFeed.where(entity_id: entities_to_delete, entity_type: entity.to_s)
+            puts "Found #{entities_imported.size} EntityImportedFromFeed #{entity.to_s}s to delete."
+            if (mode == 1 && !entities_imported.empty?)
+              puts "Deleting unreferenced EntityImportedFromFeed #{entity.to_s}s."
+              entities_imported.delete_all
             end
-          end
-          entities_imported = EntityImportedFromFeed.where(entity_id: entities_to_delete_ids, entity_type: entity.to_s)
-          puts "Found #{entities_imported.size} EntityImportedFromFeed #{entity.to_s}s to delete."
-          if (mode && !entities_imported.empty?)
-            puts "Deleting unreferenced EntityImportedFromFeed #{entity.to_s}s."
-            entities_imported.delete_all
-          end
-          puts "Found #{entities_to_delete.size} #{entity.to_s}s to delete."
-          entities_to_delete.each { |e| puts " #{entity.to_s}: #{e.onestop_id}" } if !entities_to_delete.empty?
-          if (mode == 1 && !entities_to_delete.empty?)
-            puts "Deleting unreferenced #{entity.to_s}s."
-            entities_to_delete.each { |e| e.delete }
+
+            # Delete OSR / RSS
+            if (entity == Route)
+              route_serving_stops = RouteServingStop.where(route_id: entities_to_delete)
+              puts "Found #{route_serving_stops.size} RouteServingStops to delete."
+              if (mode == 1 && !route_serving_stops.empty?)
+                puts "Deleting unreferenced RouteServingStops."
+                route_serving_stops.delete_all
+              end
+            end
+
+            if (entity == Stop)
+              operator_serving_stops = OperatorServingStop.where(stop_id: entities_to_delete)
+              puts "Found #{operator_serving_stops.size} OperatorServingStops to delete."
+              if (mode == 1 && !operator_serving_stops.empty?)
+                puts "Deleting unreferenced OperatorServingStops."
+                operator_serving_stops.delete_all
+              end
+            end
           end
         end
       rescue

--- a/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
+++ b/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
@@ -35,8 +35,8 @@ describe Api::V1::ScheduleStopPairsController do
       end
     end
 
-    context 'where_active' do
-      it 'explicitly sets where_active' do
+    context 'active' do
+      it 'explicitly sets where_imported_from_active_feed_version' do
         get :index, active: 'true', feed_version_sha1: @feed_version_inactive.sha1
         expect_json_sizes(schedule_stop_pairs: 0)
       end

--- a/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
+++ b/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
@@ -17,6 +17,9 @@ describe IsAnEntityImportedFromFeeds do
     # activate
     @feed.activate_feed_version(@fv1.sha1, 1)
     @feed.activate_feed_version(@fv2.sha1, 2)
+    # --> only stops referenced by @fv2 are active
+    #     @stop1, @stop2 active
+    #     @stop0, @stop3 inactive
   end
 
   context '.where_import_level' do
@@ -65,4 +68,12 @@ describe IsAnEntityImportedFromFeeds do
       expect(Stop.where_imported_from_feed_version(@fv2)).to match_array([@stop1, @stop2])
     end
   end
+
+  context '.where_inactive' do
+    it 'finds entities not referenced by active feed_version' do
+      # see notes in before(:each)
+      expect(Stop.where_inactive).to match_array([@stop0, @stop3])
+    end
+  end
+
 end

--- a/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
+++ b/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
@@ -28,11 +28,6 @@ describe IsAnEntityImportedFromFeeds do
       expect(Stop.where_import_level(2)).to match_array([@stop1, @stop2])
     end
 
-    # TODO: where_active
-    # it 'chains with where_active' do
-    #   expect(Stop.where_import_level(1).where_active).to match_array([@stop1])
-    # end
-
     it 'excludes non matching' do
       expect(Stop.where_import_level(0)).to match_array([])
     end
@@ -69,17 +64,17 @@ describe IsAnEntityImportedFromFeeds do
     end
   end
 
-  context '.where_active' do
+  context '.where_imported_from_active_feed_version' do
     it 'finds entities referenced by active feed_version' do
       # see notes in before(:each)
-      expect(Stop.where_active).to match_array([@stop1, @stop2])
+      expect(Stop.where_imported_from_active_feed_version).to match_array([@stop1, @stop2])
     end
   end
 
-  context '.where_inactive' do
+  context '.where_not_imported_from_active_feed_version' do
     it 'finds entities not referenced by active feed_version' do
       # see notes in before(:each)
-      expect(Stop.where_inactive).to match_array([@stop0, @stop3])
+      expect(Stop.where_not_imported_from_active_feed_version).to match_array([@stop0, @stop3])
     end
   end
 

--- a/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
+++ b/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
@@ -69,6 +69,13 @@ describe IsAnEntityImportedFromFeeds do
     end
   end
 
+  context '.where_active' do
+    it 'finds entities referenced by active feed_version' do
+      # see notes in before(:each)
+      expect(Stop.where_active).to match_array([@stop1, @stop2])
+    end
+  end
+
   context '.where_inactive' do
     it 'finds entities not referenced by active feed_version' do
       # see notes in before(:each)

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -322,7 +322,7 @@ describe Feed do
       expect(@fv1.imported_schedule_stop_pairs.count).to eq(1)
       @feed.deactivate_feed_version(@fv1.sha1)
       expect(@fv1.imported_schedule_stop_pairs.count).to eq(0)
-      expect(@feed.imported_schedule_stop_pairs.where_active).to match_array([@ssp2])
+      expect(@feed.imported_schedule_stop_pairs.where_imported_from_active_feed_version).to match_array([@ssp2])
     end
 
     it 'cannot deactivate current active_feed_version' do

--- a/spec/models/schedule_stop_pair_spec.rb
+++ b/spec/models/schedule_stop_pair_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe ScheduleStopPair, type: :model do
   end
 
   context 'scopes' do
-    it 'where_active' do
+    it 'where_imported_from_active_feed_version' do
       feed = create(:feed)
       feed_version1 = create(:feed_version, feed: feed)
       feed_version2 = create(:feed_version, feed: feed)
@@ -165,7 +165,7 @@ RSpec.describe ScheduleStopPair, type: :model do
       ssp1 = create(:schedule_stop_pair, feed_version: feed_version1, feed: feed)
       ssp2 = create(:schedule_stop_pair, feed_version: feed_version2, feed: feed)
       expect(ScheduleStopPair.all).to match_array([ssp1, ssp2])
-      expect(ScheduleStopPair.where_active).to match_array([ssp2])
+      expect(ScheduleStopPair.where_imported_from_active_feed_version).to match_array([ssp2])
     end
 
     it 'where_import_level' do


### PR DESCRIPTION
Adds `where_imported_from_active_feed_version ` and `where_not_imported_from_active_feed_version ` scopes for entities imported from a feed.

Resolves #540
