### PR TITLE
Correctly rm cached files

### DIFF
--- a/app/models/feed_version.rb
+++ b/app/models/feed_version.rb
@@ -82,8 +82,13 @@ class FeedVersion < ActiveRecord::Base
   def open_gtfs
     fail StandardError.new('No file') unless file.present?
     filename = file.local_path_copying_locally_if_needed
-    yield gtfs_source_build(filename)
+    gtfs = GTFS::Source.build(
+      filename,
+      strict: false,
+      tmpdir_basepath: Figaro.env.gtfs_tmpdir_basepath.presence
+    )
     file.remove_any_local_cached_copies
+    gtfs
   end
 
   def download_url
@@ -96,14 +101,6 @@ class FeedVersion < ActiveRecord::Base
   end
 
   private
-
-  def gtfs_source_build(source)
-    GTFS::Source.build(
-      source,
-      strict: false,
-      tmpdir_basepath: Figaro.env.gtfs_tmpdir_basepath.presence
-    )
-  end
 
   def compute_and_set_hashes
     if file.present? && file_changed?

--- a/app/services/gtfs_graph.rb
+++ b/app/services/gtfs_graph.rb
@@ -10,8 +10,7 @@ class GTFSGraph
     # GTFS Graph / TransitLand wrapper
     @feed = feed
     @feed_version = feed_version
-    @gtfs = nil
-    @feed_version.open_gtfs { |gtfs| @gtfs = gtfs }
+    @gtfs = @feed_version.open_gtfs
 
     @log = []
     # GTFS entity to Onestop ID

--- a/app/uploaders/feed_version_uploader.rb
+++ b/app/uploaders/feed_version_uploader.rb
@@ -29,8 +29,6 @@ class FeedVersionUploader < CarrierWave::Uploader::Base
   end
 
   def remove_any_local_cached_copies
-    if url && url.start_with?('http')
-      FileUtils.rm_rf(File.dirname(path)) if cached?
-    end
+    FileUtils.rm_rf(File.dirname(path)) if cached?
   end
 end

--- a/spec/models/feed_version_spec.rb
+++ b/spec/models/feed_version_spec.rb
@@ -35,21 +35,6 @@ describe FeedVersion do
     end
   end
 
-  context '#read_gtfs_info' do
-    it 'reads earliest and latest dates from calendars.txt' do
-      feed_version = create(:feed_version_bart)
-      expect(feed_version.earliest_calendar_date).to eq Date.parse('2013-11-28')
-      expect(feed_version.latest_calendar_date).to eq Date.parse('2017-01-01')
-    end
-    it 'reads feed_info.txt and puts into tags' do
-      feed_version = create(:feed_version_bart)
-      expect(feed_version.tags['feed_lang']).to eq 'en'
-      expect(feed_version.tags['feed_version']).to eq '36'
-      expect(feed_version.tags['feed_publisher_url']).to eq 'http://www.bart.gov'
-      expect(feed_version.tags['feed_publisher_name']).to eq 'Bay Area Rapid Transit'
-    end
-  end
-
   context '#delete_schedule_stop_pairs' do
     before(:each) do
       @feed_version = create(:feed_version)

--- a/spec/services/feed_fetcher_service_spec.rb
+++ b/spec/services/feed_fetcher_service_spec.rb
@@ -104,6 +104,31 @@ describe FeedFetcherService do
     end
   end
 
+  context '#read_gtfs_info' do
+    it 'reads earliest and latest dates from calendars.txt' do
+      feed = create(:feed, url: example_url)
+      feed_version = nil
+      VCR.use_cassette('feed_fetch_example_local') do
+        feed_version = FeedFetcherService.fetch_and_normalize_feed_version(feed)
+        feed_version.save!
+      end
+      expect(feed_version.earliest_calendar_date).to eq Date.parse('2007-01-01')
+      expect(feed_version.latest_calendar_date).to eq Date.parse('2010-12-31')
+    end
+    it 'reads feed_info.txt and puts into tags' do
+      feed = create(:feed, url: example_url)
+      feed_version = nil
+      VCR.use_cassette('feed_fetch_example_local') do
+        feed_version = FeedFetcherService.fetch_and_normalize_feed_version(feed)
+        feed_version.save!
+      end
+      expect(feed_version.tags['feed_lang']).to eq 'en-US'
+      expect(feed_version.tags['feed_version']).to eq '1.0'
+      expect(feed_version.tags['feed_publisher_url']).to eq 'http://google.com'
+      expect(feed_version.tags['feed_publisher_name']).to eq 'Google'
+    end
+  end
+
   context '#fetch_and_normalize' do
     it 'downloads feed' do
       feed = create(:feed, url: example_url)


### PR DESCRIPTION
file.url is replaced after caching, points to the local filesystem copy, not the s3 http url.
(looks like an earlier fix I made was not correct in #602)

Also, move `FeedVersion#read_gtfs_info` into FeedFetcherService.

Resolves #791 