### PR TITLE
API info

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,0 +1,23 @@
+class Api::ApiController < Api::V1::BaseApiController
+  def index
+    json = Rails.cache.fetch('API_JSON_RESPONSE', expires_in: 1.day) do
+      version = TransitlandDatastore::Application::VERSION
+      {
+        datastore: {
+          version: version,
+          documentation: 'https://transit.land/documentation/datastore/',
+          code: "https://github.com/transitland/transitland-datastore/tree/#{version}",
+          release_notes: "https://github.com/transitland/transitland-datastore/releases/tag/#{version}"
+        },
+        api_versions: {
+          v1: {
+            base_url: api_v1_url,
+            kind: Api::V1::BaseApiController::API_KIND
+          }
+        }
+      }
+    end
+
+    render json: json
+  end
+end

--- a/app/controllers/api/v1/api_v1_controller.rb
+++ b/app/controllers/api/v1/api_v1_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::ApiV1Controller < Api::V1::BaseApiController
+  def index
+    json = Rails.cache.fetch('API_V1_JSON_RESPONSE', expires_in: 1.day) do
+      {
+        api: {
+          base_url: api_v1_url,
+          documentation: 'https://transit.land/documentation/datastore/api-endpoints.html',
+          swagger_description_url: 'https://github.com/transitland/transitland/issues/33', # TODO:
+          endpoints: array_of_endpoints
+        },
+      }
+    end
+
+    render json: json
+  end
+
+  private
+
+  def array_of_endpoints
+    # based on http://stackoverflow.com/a/19627954/40956
+    routes = []
+    Rails.application.routes.routes.each do |route|
+      path = route.path.spec.to_s
+      next unless path.starts_with?('/api/v1/')
+      path.gsub!(/\(\.:format\)/, "").gsub!('/api/v1', '')
+      verb = %W{ GET POST PUT PATCH DELETE }.grep(route.verb).first.downcase.to_sym
+      routes << { path: path, verb: verb }
+    end
+    routes
+  end
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+  API_KIND = 'JSON-psuedo-RESTful'
+
   protect_from_forgery with: :null_session
 
   before_filter :set_default_response_format

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -16,11 +16,6 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
     properties[:route_stop_patterns_by_onestop_id] = entity.route_stop_patterns.map(&:onestop_id)
   }
 
-  RESPONSE_FORMATS_BY_ACTION = {
-    :index => [:json, :geojson],
-    :show => [:json, :geojson],
-  }
-
   before_action :set_route, only: [:show]
 
   def index

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -16,6 +16,11 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
     properties[:route_stop_patterns_by_onestop_id] = entity.route_stop_patterns.map(&:onestop_id)
   }
 
+  RESPONSE_FORMATS_BY_ACTION = {
+    :index => [:json, :geojson],
+    :show => [:json, :geojson],
+  }
+
   before_action :set_route, only: [:show]
 
   def index

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,0 +1,5 @@
+module TransitlandDatastore
+  class Application
+    VERSION = "4.9.8"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.default_url_options = TransitlandDatastore::Application
 
 Rails.application.routes.draw do
   namespace :api do
+    get '/', to: 'api#index'
     namespace :v1 do
+      get '/', to: 'api_v1#index'
       get '/onestop_id/:onestop_id', to: 'onestop_id#show'
       get '/activity_updates', to: 'activity_updates#index'
       resources :changesets, only: [:index, :show, :create, :update, :destroy] do

--- a/doc/development-practices.md
+++ b/doc/development-practices.md
@@ -19,3 +19,10 @@ We're testing out an automatic way of generating [CHANGELOG.md](../CHANGELOG.md)
 3. `github_changelog_generator -t XXXXXXXX` where XXXXXXXX is the GitHub personal access token.
 
 The change log can be updated with each pull request to master. But it's only actually important to do it with production releases, each of which gets a new version number and git tag.
+
+### Version number
+
+We keep track of version numbers in two places:
+
+- Committed to code in `config/initializers/version.rb`.
+- Tags on the git repository, listed at https://github.com/transitland/transitland-datastore/tags

--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,8 @@
   </head>
   <body>
     <h1>Transitland Datastore</h1>
-    <p>For a general introduction to Transitland, see <a href="http://transit.land">transit.land</a></p>
-    <p>To try querying data in the Datastore, try the <a href="http://playground.transit.land">Playground</a></p>
-    <p>For more information about the Datastore API, see the <a href="https://github.com/transitland/transitland-datastore#api-endpoints">readme on Github</a></p>
+    <p>For a general introduction to Transitland, see <a href="https://transit.land">transit.land</a></p>
+    <p>To try querying data in the Datastore, try the <a href="https://transit.land/playground">Playground</a></p>
+    <p>For more information about the Datastore API, see its <a href="https://transit.land/documentation/datastore/">documentation</a></p>
   </body>
 </html>


### PR DESCRIPTION
closes #719

`http://transit.land/api` will now return:

![screen shot 2016-10-04 at 9 43 23 pm](https://cloud.githubusercontent.com/assets/212369/19101260/99f59d26-8a7b-11e6-9d1c-29d3489ed5d6.png)

`http://transit.land/api/v1` will now return:

![screencapture-localhost-3000-api-v1-1475642645619](https://cloud.githubusercontent.com/assets/212369/19101276/b66098da-8a7b-11e6-899a-b302fff8f9bd.png)
