### PR TITLE
Convert logging message to string

### DIFF
--- a/config/initializers/logging.rb
+++ b/config/initializers/logging.rb
@@ -1,4 +1,5 @@
 def log(msg, level = :info)
+  msg = msg.to_s
   if Sidekiq::Logging.logger
     Sidekiq::Logging.logger.send level, msg
   elsif Rails.logger


### PR DESCRIPTION
Fails on array, integer, float, etc.

Resolves #850