### PR TITLE
Find by gtfs_id

### DIFF
--- a/app/controllers/api/v1/feeds_controller.rb
+++ b/app/controllers/api/v1/feeds_controller.rb
@@ -6,45 +6,52 @@ class Api::V1::FeedsController < Api::V1::BaseApiController
   before_action :set_feed, only: [:show]
 
   def index
-    @feeds = Feed.where('').includes{[
+    # Entity
+    @feeds = Feed.where('')
+    @feeds = AllowFiltering.by_onestop_id(@feeds, params)
+    @feeds = AllowFiltering.by_tag_keys_and_values(@feeds, params)
+    @feeds = AllowFiltering.by_identifer_and_identifier_starts_with(@feeds, params)
+    @feeds = AllowFiltering.by_updated_since(@feeds, params)
+
+    # Geometry
+    if [params[:lat], params[:lon]].map(&:present?).all?
+      point = Feed::GEOFACTORY.point(params[:lon], params[:lat])
+      r = params[:r] || 100 # meters TODO: move this to a more logical place
+      @feeds = @feeds.where{st_dwithin(geometry, point, r)}.order{st_distance(geometry, point)}
+    end
+    if params[:bbox].present?
+      @feeds = @feeds.geometry_within_bbox(params[:bbox])
+    end
+
+    # Feeds
+    @feeds = AllowFiltering.by_attribute_since(@feeds, params, :last_imported_since, :last_imported_at)
+    if params[:latest_fetch_exception].present?
+      @feeds = @feeds.where_latest_fetch_exception(AllowFiltering.to_boolean(params[:latest_fetch_exception]))
+    end
+    if params[:active_feed_version_valid].present?
+      @feeds = @feeds.where_active_feed_version_valid(params[:active_feed_version_valid])
+    end
+    if params[:active_feed_version_expired].present?
+      @feeds = @feeds.where_active_feed_version_expired(params[:active_feed_version_expired])
+    end
+    if params[:active_feed_version_update].presence == 'true'
+      @feeds = @feeds.where_active_feed_version_update
+    end
+    if params[:active_feed_version_import_level].present?
+      @feeds = @feeds.where_active_feed_version_import_level(params[:active_feed_version_import_level])
+    end
+    if params[:latest_feed_version_import_status].present?
+      @feeds = @feeds.where_latest_feed_version_import_status(AllowFiltering.to_boolean(params[:latest_feed_version_import_status]))
+    end
+
+    # Includes
+    @feeds = @feeds.includes{[
       operators_in_feed,
       operators_in_feed.operator,
       changesets_imported_from_this_feed,
       active_feed_version,
       feed_versions
     ]}
-
-    @feeds = AllowFiltering.by_onestop_id(@feeds, params)
-    @feeds = AllowFiltering.by_tag_keys_and_values(@feeds, params)
-    @feeds = AllowFiltering.by_attribute_since(@feeds, params, :last_imported_since, :last_imported_at)
-
-    if params[:latest_fetch_exception].present?
-      @feeds = @feeds.where_latest_fetch_exception(AllowFiltering.to_boolean(params[:latest_fetch_exception]))
-    end
-
-    if params[:bbox].present?
-      @feeds = @feeds.geometry_within_bbox(params[:bbox])
-    end
-
-    if params[:active_feed_version_valid].present?
-      @feeds = @feeds.where_active_feed_version_valid(params[:active_feed_version_valid])
-    end
-
-    if params[:active_feed_version_expired].present?
-      @feeds = @feeds.where_active_feed_version_expired(params[:active_feed_version_expired])
-    end
-
-    if params[:active_feed_version_update].presence == 'true'
-      @feeds = @feeds.where_active_feed_version_update
-    end
-
-    if params[:active_feed_version_import_level].present?
-      @feeds = @feeds.where_active_feed_version_import_level(params[:active_feed_version_import_level])
-    end
-
-    if params[:latest_feed_version_import_status].present?
-      @feeds = @feeds.where_latest_feed_version_import_status(AllowFiltering.to_boolean(params[:latest_feed_version_import_status]))
-    end
 
     respond_to do |format|
       format.json { render paginated_json_collection(@feeds) }

--- a/app/controllers/api/v1/route_stop_patterns_controller.rb
+++ b/app/controllers/api/v1/route_stop_patterns_controller.rb
@@ -6,41 +6,52 @@ class Api::V1::RouteStopPatternsController < Api::V1::BaseApiController
   before_action :set_route_stop_pattern, only: [:show]
 
   def index
+    # Entity
     @rsps = RouteStopPattern.where('')
-
     @rsps = AllowFiltering.by_onestop_id(@rsps, params)
     @rsps = AllowFiltering.by_tag_keys_and_values(@rsps, params)
     @rsps = AllowFiltering.by_identifer_and_identifier_starts_with(@rsps, params)
     @rsps = AllowFiltering.by_updated_since(@rsps, params)
 
+    # Imported From Feed
     if params[:imported_from_feed].present?
       @rsps = @rsps.where_imported_from_feed(Feed.find_by_onestop_id(params[:imported_from_feed]))
     end
-
     if params[:imported_from_feed_version].present?
       @rsps = @rsps.where_imported_from_feed_version(FeedVersion.find_by!(sha1: params[:imported_from_feed_version]))
     end
-
-    if params[:bbox].present?
-      @rsps = @rsps.geometry_within_bbox(params[:bbox])
+    if params[:imported_from_active_feed_version].presence.eql?("true")
+      @rsps = @rsps.where_imported_from_active_feed_version
     end
-
-    if params[:traversed_by].present?
-      @rsps = @rsps.where(route: Route.find_by_onestop_id!(params[:traversed_by]))
+    if params[:imported_with_gtfs_id].present?
+      @rsps = @rsps.where_imported_with_gtfs_id(params[:gtfs_id])
     end
-
-    if params[:trips].present?
-      @rsps = @rsps.with_trips(params[:trips])
-    end
-
-    if params[:stops_visited].present?
-      @rsps = @rsps.with_stops(params[:stops_visited])
-    end
-
     if params[:import_level].present?
       @rsps = @rsps.where_import_level(AllowFiltering.param_as_array(params, :import_level))
     end
 
+    # Geometry
+    if [params[:lat], params[:lon]].map(&:present?).all?
+      point = RouteStopPattern::GEOFACTORY.point(params[:lon], params[:lat])
+      r = params[:r] || 100 # meters TODO: move this to a more logical place
+      @rsps = @rsps.where{st_dwithin(geometry, point, r)}.order{st_distance(geometry, point)}
+    end
+    if params[:bbox].present?
+      @rsps = @rsps.geometry_within_bbox(params[:bbox])
+    end
+
+    # RouteStopPatterns
+    if params[:traversed_by].present?
+      @rsps = @rsps.where(route: Route.find_by_onestop_id!(params[:traversed_by]))
+    end
+    if params[:trips].present?
+      @rsps = @rsps.with_trips(params[:trips])
+    end
+    if params[:stops_visited].present?
+      @rsps = @rsps.with_stops(params[:stops_visited])
+    end
+
+    # Includes
     @rsps = @rsps.includes{[
       route,
       imported_from_feeds,

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -37,7 +37,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       @routes = @routes.where{st_dwithin(geometry, point, r)}.order{st_distance(geometry, point)}
     end
     if params[:bbox].present?
-      @routes = @routes.geometry_within_bbox(params[:bbox])
+      @routes = @routes.stop_within_bbox(params[:bbox])
     end
 
     # Routes

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -6,25 +6,44 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
   before_action :set_route, only: [:show]
 
   def index
+    # Entity
     @routes = Route.where('')
-
     @routes = AllowFiltering.by_onestop_id(@routes, params)
     @routes = AllowFiltering.by_tag_keys_and_values(@routes, params)
     @routes = AllowFiltering.by_identifer_and_identifier_starts_with(@routes, params)
     @routes = AllowFiltering.by_updated_since(@routes, params)
 
+    # Imported From Feed
     if params[:imported_from_feed].present?
       @routes = @routes.where_imported_from_feed(Feed.find_by_onestop_id(params[:imported_from_feed]))
     end
-
     if params[:imported_from_feed_version].present?
       @routes = @routes.where_imported_from_feed_version(FeedVersion.find_by!(sha1: params[:imported_from_feed_version]))
     end
+    if params[:imported_from_active_feed_version].presence.eql?("true")
+      @routes = @routes.where_imported_from_active_feed_version
+    end
+    if params[:imported_with_gtfs_id].present?
+      @routes = @routes.where_imported_with_gtfs_id(params[:gtfs_id])
+    end
+    if params[:import_level].present?
+      @routes = @routes.where_import_level(AllowFiltering.param_as_array(params, :import_level))
+    end
 
+    # Geometry
+    if [params[:lat], params[:lon]].map(&:present?).all?
+      point = Route::GEOFACTORY.point(params[:lon], params[:lat])
+      r = params[:r] || 100 # meters TODO: move this to a more logical place
+      @routes = @routes.where{st_dwithin(geometry, point, r)}.order{st_distance(geometry, point)}
+    end
+    if params[:bbox].present?
+      @routes = @routes.geometry_within_bbox(params[:bbox])
+    end
+
+    # Routes
     if params[:serves].present?
       @routes = @routes.where_serves(AllowFiltering.param_as_array(params, :serves))
     end
-
     if params[:operated_by].present? || params[:operatedBy].present?
       # we previously allowed `operatedBy`, so we'll continue to honor that for the time being
       param = params[:operated_by].present? ? :operated_by : :operatedBy
@@ -38,9 +57,6 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       # some could be integers, some could be strings
       @routes = @routes.where_vehicle_type(AllowFiltering.param_as_array(params, :vehicle_type))
     end
-    if params[:bbox].present?
-      @routes = @routes.stop_within_bbox(params[:bbox])
-    end
     if params[:color].present?
       if ['true', true].include?(params[:color])
         @routes = @routes.where.not(color: nil)
@@ -48,10 +64,6 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
         @routes = @routes.where(color: params[:color].upcase)
       end
     end
-    if params[:import_level].present?
-      @routes = @routes.where_import_level(AllowFiltering.param_as_array(params, :import_level))
-    end
-
     if params[:wheelchair_accessible].present?
       @routes = @routes.where(wheelchair_accessible: params[:wheelchair_accessible])
     end
@@ -59,6 +71,7 @@ class Api::V1::RoutesController < Api::V1::BaseApiController
       @routes = @routes.where(bikes_allowed: params[:bikes_allowed])
     end
 
+    # Includes
     @routes = @routes.includes{[
       operator,
       stops,

--- a/app/controllers/api/v1/stop_stations_controller.rb
+++ b/app/controllers/api/v1/stop_stations_controller.rb
@@ -6,29 +6,31 @@ class Api::V1::StopStationsController < Api::V1::BaseApiController
   before_action :set_stop, only: [:show]
 
   def index
+    # Entity
     @stops = Stop.where(type: nil)
-
     @stops = AllowFiltering.by_onestop_id(@stops, params)
     @stops = AllowFiltering.by_tag_keys_and_values(@stops, params)
     @stops = AllowFiltering.by_identifer_and_identifier_starts_with(@stops, params)
     @stops = AllowFiltering.by_updated_since(@stops, params)
 
+    # Imported From Feed
     if params[:imported_from_feed].present?
       @stops = @stops.where_imported_from_feed(Feed.find_by_onestop_id(params[:imported_from_feed]))
     end
-
     if params[:imported_from_feed_version].present?
       @stops = @stops.where_imported_from_feed_version(FeedVersion.find_by!(sha1: params[:imported_from_feed_version]))
     end
-
-    if params[:served_by].present? || params[:servedBy].present?
-      # we previously allowed `servedBy`, so we'll continue to honor that for the time being
-      operator_onestop_ids = []
-      operator_onestop_ids += params[:served_by].split(',') if params[:served_by].present?
-      operator_onestop_ids += params[:servedBy].split(',') if params[:servedBy].present?
-      operator_onestop_ids.uniq!
-      @stops = @stops.served_by(operator_onestop_ids)
+    if params[:imported_from_active_feed_version].presence.eql?("true")
+      @stops = @stops.where_imported_from_active_feed_version
     end
+    if params[:imported_with_gtfs_id].present?
+      @stops = @stops.where_imported_with_gtfs_id(params[:gtfs_id])
+    end
+    if params[:import_level].present?
+      @stops = @stops.where_import_level(AllowFiltering.param_as_array(params, :import_level))
+    end
+
+    # Geometry
     if [params[:lat], params[:lon]].map(&:present?).all?
       point = Stop::GEOFACTORY.point(params[:lon], params[:lat])
       r = params[:r] || 100 # meters TODO: move this to a more logical place
@@ -37,9 +39,23 @@ class Api::V1::StopStationsController < Api::V1::BaseApiController
     if params[:bbox].present?
       @stops = @stops.geometry_within_bbox(params[:bbox])
     end
-    if params[:import_level].present?
-      @stops = @stops.where_import_level(AllowFiltering.param_as_array(params, :import_level))
+
+    # Stop
+    if params[:served_by].present? || params[:servedBy].present?
+      # we previously allowed `servedBy`, so we'll continue to honor that for the time being
+      operator_onestop_ids = []
+      operator_onestop_ids += params[:served_by].split(',') if params[:served_by].present?
+      operator_onestop_ids += params[:servedBy].split(',') if params[:servedBy].present?
+      operator_onestop_ids.uniq!
+      @stops = @stops.served_by(operator_onestop_ids)
     end
+    if params[:served_by_vehicle_types].present?
+      @stops = @stops.served_by_vehicle_types(AllowFiltering.param_as_array(params, :served_by_vehicle_types))
+    end
+    if params[:wheelchair_boarding].present?
+      @stops = @stops.where(wheelchair_boarding: AllowFiltering.to_boolean(params[:wheelchair_boarding] ))
+    end
+
     # TODO: served_by_vehicle_types
 
     @stops = @stops.includes{[

--- a/app/controllers/api/v1/stops_controller.rb
+++ b/app/controllers/api/v1/stops_controller.rb
@@ -21,6 +21,10 @@ class Api::V1::StopsController < Api::V1::BaseApiController
       @stops = @stops.where_imported_from_feed_version(FeedVersion.find_by!(sha1: params[:imported_from_feed_version]))
     end
 
+    if params[:imported_from_active_feed_version].presence.eql?("true")
+      @stops = @stops.where_imported_from_active_feed_version
+    end
+
     if params[:gtfs_id].present?
       @stops = @stops.where_imported_with_gtfs_id(params[:gtfs_id])
     end

--- a/app/controllers/api/v1/stops_controller.rb
+++ b/app/controllers/api/v1/stops_controller.rb
@@ -21,6 +21,10 @@ class Api::V1::StopsController < Api::V1::BaseApiController
       @stops = @stops.where_imported_from_feed_version(FeedVersion.find_by!(sha1: params[:imported_from_feed_version]))
     end
 
+    if params[:gtfs_id].present?
+      @stops = @stops.where_imported_with_gtfs_id(params[:gtfs_id])
+    end
+
     if params[:served_by].present? || params[:servedBy].present?
       # we previously allowed `servedBy`, so we'll continue to honor that for the time being
       operator_onestop_ids = []
@@ -94,6 +98,7 @@ class Api::V1::StopsController < Api::V1::BaseApiController
       :tag_key,
       :tag_value,
       :import_level,
+      :gtfs_id,
       :imported_from_feed,
       :imported_from_feed_version
     )

--- a/app/controllers/api/v1/stops_controller.rb
+++ b/app/controllers/api/v1/stops_controller.rb
@@ -6,37 +6,31 @@ class Api::V1::StopsController < Api::V1::BaseApiController
   before_action :set_stop, only: [:show]
 
   def index
+    # Entity
     @stops = Stop.where('')
-
     @stops = AllowFiltering.by_onestop_id(@stops, params)
     @stops = AllowFiltering.by_tag_keys_and_values(@stops, params)
     @stops = AllowFiltering.by_identifer_and_identifier_starts_with(@stops, params)
     @stops = AllowFiltering.by_updated_since(@stops, params)
 
+    # Imported From Feed
     if params[:imported_from_feed].present?
       @stops = @stops.where_imported_from_feed(Feed.find_by_onestop_id(params[:imported_from_feed]))
     end
-
     if params[:imported_from_feed_version].present?
       @stops = @stops.where_imported_from_feed_version(FeedVersion.find_by!(sha1: params[:imported_from_feed_version]))
     end
-
     if params[:imported_from_active_feed_version].presence.eql?("true")
       @stops = @stops.where_imported_from_active_feed_version
     end
-
-    if params[:gtfs_id].present?
+    if params[:imported_with_gtfs_id].present?
       @stops = @stops.where_imported_with_gtfs_id(params[:gtfs_id])
     end
-
-    if params[:served_by].present? || params[:servedBy].present?
-      # we previously allowed `servedBy`, so we'll continue to honor that for the time being
-      operator_onestop_ids = []
-      operator_onestop_ids += params[:served_by].split(',') if params[:served_by].present?
-      operator_onestop_ids += params[:servedBy].split(',') if params[:servedBy].present?
-      operator_onestop_ids.uniq!
-      @stops = @stops.served_by(operator_onestop_ids)
+    if params[:import_level].present?
+      @stops = @stops.where_import_level(AllowFiltering.param_as_array(params, :import_level))
     end
+
+    # Geometry
     if [params[:lat], params[:lon]].map(&:present?).all?
       point = Stop::GEOFACTORY.point(params[:lon], params[:lat])
       r = params[:r] || 100 # meters TODO: move this to a more logical place
@@ -45,8 +39,15 @@ class Api::V1::StopsController < Api::V1::BaseApiController
     if params[:bbox].present?
       @stops = @stops.geometry_within_bbox(params[:bbox])
     end
-    if params[:import_level].present?
-      @stops = @stops.where_import_level(AllowFiltering.param_as_array(params, :import_level))
+
+    # Stop
+    if params[:served_by].present? || params[:servedBy].present?
+      # we previously allowed `servedBy`, so we'll continue to honor that for the time being
+      operator_onestop_ids = []
+      operator_onestop_ids += params[:served_by].split(',') if params[:served_by].present?
+      operator_onestop_ids += params[:servedBy].split(',') if params[:servedBy].present?
+      operator_onestop_ids.uniq!
+      @stops = @stops.served_by(operator_onestop_ids)
     end
     if params[:served_by_vehicle_types].present?
       @stops = @stops.served_by_vehicle_types(AllowFiltering.param_as_array(params, :served_by_vehicle_types))
@@ -55,6 +56,7 @@ class Api::V1::StopsController < Api::V1::BaseApiController
       @stops = @stops.where(wheelchair_boarding: AllowFiltering.to_boolean(params[:wheelchair_boarding] ))
     end
 
+    # Includes
     @stops = @stops.includes{[
       operators_serving_stop,
       operators_serving_stop.operator,

--- a/app/models/concerns/is_an_entity_imported_from_feeds.rb
+++ b/app/models/concerns/is_an_entity_imported_from_feeds.rb
@@ -40,8 +40,12 @@ module IsAnEntityImportedFromFeeds
       where(id: self.all.select(:id).pluck(:id) - self.where_imported_from_active_feed_version.select(:id).pluck(:id))
     }
 
-    scope :where_imported_with_gtfs_id, -> (gtfs_id) -> {
-
+    scope :where_imported_with_gtfs_id, -> (gtfs_id) {
+      joins(:entities_imported_from_feed)
+        .where(entities_imported_from_feed: {
+          gtfs_id: gtfs_id
+        })
+        .distinct
     }
 
     attr_accessor :add_imported_from_feeds, :not_imported_from_feeds

--- a/app/models/concerns/is_an_entity_imported_from_feeds.rb
+++ b/app/models/concerns/is_an_entity_imported_from_feeds.rb
@@ -12,6 +12,7 @@ module IsAnEntityImportedFromFeeds
         })
         .distinct
     }
+
     scope :where_imported_from_feed, -> (feed) {
       joins(:entities_imported_from_feed)
         .where(entities_imported_from_feed: {
@@ -19,6 +20,7 @@ module IsAnEntityImportedFromFeeds
         })
         .distinct
     }
+
     scope :where_imported_from_feed_version, -> (feed_version) {
       joins(:entities_imported_from_feed)
         .where(entities_imported_from_feed: {
@@ -36,6 +38,10 @@ module IsAnEntityImportedFromFeeds
     scope :where_not_imported_from_active_feed_version, -> {
       # This may be possible with a complex outer join, but this will do.
       where(id: self.all.select(:id).pluck(:id) - self.where_imported_from_active_feed_version.select(:id).pluck(:id))
+    }
+
+    scope :where_imported_with_gtfs_id, -> (gtfs_id) -> {
+
     }
 
     attr_accessor :add_imported_from_feeds, :not_imported_from_feeds

--- a/spec/controllers/api/v1/stops_controller_spec.rb
+++ b/spec/controllers/api/v1/stops_controller_spec.rb
@@ -67,7 +67,6 @@ describe Api::V1::StopsController do
             expect(stops.map { |stop| stop[:onestop_id] }).to match_array([@stop1.onestop_id, @stop2.onestop_id])
           }})
         end
-
       end
 
       context 'returns stop by servedBy' do

--- a/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
+++ b/spec/models/concerns/is_an_entity_imported_from_feeds_spec.rb
@@ -10,10 +10,10 @@ describe IsAnEntityImportedFromFeeds do
     @fv1 = create(:feed_version, feed: @feed)
     @fv2 = create(:feed_version, feed: @feed)
     # add EIFFs; stop0 in fv1; stop1 in fv1, fv2; stop2 in fv2
-    @fv1.entities_imported_from_feed.create!(entity: @stop0, feed: @feed)
-    @fv1.entities_imported_from_feed.create!(entity: @stop1, feed: @feed)
-    @fv2.entities_imported_from_feed.create!(entity: @stop1, feed: @feed)
-    @fv2.entities_imported_from_feed.create!(entity: @stop2, feed: @feed)
+    @fv1.entities_imported_from_feed.create!(entity: @stop0, feed: @feed, gtfs_id: "0")
+    @fv1.entities_imported_from_feed.create!(entity: @stop1, feed: @feed, gtfs_id: "1")
+    @fv2.entities_imported_from_feed.create!(entity: @stop1, feed: @feed, gtfs_id: "1")
+    @fv2.entities_imported_from_feed.create!(entity: @stop2, feed: @feed, gtfs_id: "2")
     # activate
     @feed.activate_feed_version(@fv1.sha1, 1)
     @feed.activate_feed_version(@fv2.sha1, 2)
@@ -118,6 +118,25 @@ describe IsAnEntityImportedFromFeeds do
     it 'finds entities not referenced by active feed_version' do
       # see notes in before(:each)
       expect(Stop.where_not_imported_from_active_feed_version).to match_array([@stop0, @stop3])
+    end
+  end
+
+  context '.where_imported_with_gtfs_id' do
+    it 'finds entities imported with a gtfs_id' do
+      expect(Stop.where_imported_with_gtfs_id('0')).to match_array([@stop0])
+      expect(Stop.where_imported_with_gtfs_id('1')).to match_array([@stop1])
+    end
+
+    it 'finds entities imported with a gtfs_id from a feed' do
+      feed2 = create(:feed)
+      expect(Stop.where_imported_with_gtfs_id('0').where_imported_from_feed(@feed)).to match_array([@stop0])
+      expect(Stop.where_imported_with_gtfs_id('0').where_imported_from_feed(feed2)).to match_array([])
+    end
+
+    it 'finds entities imported from an active feed version with gtfs_id' do
+      feed2 = create(:feed)
+      expect(Stop.where_imported_with_gtfs_id('0').where_imported_from_feed(@feed).where_imported_from_active_feed_version).to match_array([])
+      expect(Stop.where_imported_with_gtfs_id('1').where_imported_from_feed(@feed).where_imported_from_active_feed_version).to match_array([@stop1])
     end
   end
 


### PR DESCRIPTION
1. Adds `where_imported_with_gtfs_id` scope to `EntitiesImportedFromFeed` to find entities by GTFS ID.
2. Adds `imported_with_gtfs_id` query param to Entity controllers.
3. Cleans up & standardizes common query parameters across Entity controllers.

Resolves #942
Resolves #943
