### PR TITLE
gtfs gem update: support ftp & additional feed/agency contact details.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', tag: 'd693bdad4f563373cc9eac74342fc67ebd072e59'
+gem 'gtfs', github: 'transitland/gtfs', tag: '3a0e59596f2713e6469bbd2f5b53b3be94ffa69f'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema', '2.5.2' # running into problems with 2.6.0

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'whenever', require: false # to manage crontab
 # data model
 gem 'squeel'
 gem 'enumerize'
-gem 'gtfs', github: 'transitland/gtfs', tag: '2bddc81bdcad6cd6122bc7988dc4e1e11f515af9'
+gem 'gtfs', github: 'transitland/gtfs', tag: 'd693bdad4f563373cc9eac74342fc67ebd072e59'
 gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema', '2.5.2' # running into problems with 2.6.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: 2bddc81bdcad6cd6122bc7988dc4e1e11f515af9
-  tag: 2bddc81bdcad6cd6122bc7988dc4e1e11f515af9
+  revision: d693bdad4f563373cc9eac74342fc67ebd072e59
+  tag: d693bdad4f563373cc9eac74342fc67ebd072e59
   specs:
     gtfs (1.0.1)
       multi_json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GIT
 
 GIT
   remote: git://github.com/transitland/gtfs.git
-  revision: d693bdad4f563373cc9eac74342fc67ebd072e59
-  tag: d693bdad4f563373cc9eac74342fc67ebd072e59
+  revision: 3a0e59596f2713e6469bbd2f5b53b3be94ffa69f
+  tag: 3a0e59596f2713e6469bbd2f5b53b3be94ffa69f
   specs:
     gtfs (1.0.1)
       multi_json

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -158,6 +158,7 @@ class Operator < BaseOperator
     operator.tags[:agency_lang] = entity.agency_lang
     operator.tags[:agency_fare_url] = entity.agency_fare_url
     operator.tags[:agency_id] = entity.id
+    operator.tags[:agency_email] = entity.agency_email
     operator.timezone = entity.agency_timezone
     operator.website = entity.agency_url
     operator

--- a/app/services/feed_fetcher_service.rb
+++ b/app/services/feed_fetcher_service.rb
@@ -161,7 +161,9 @@ class FeedFetcherService
         feed_start_date:     feed_info.feed_start_date,
         feed_end_date:       feed_info.feed_end_date,
         feed_version:        feed_info.feed_version,
-        feed_id:             feed_info.feed_id
+        feed_id:             feed_info.feed_id,
+        feed_contact_email:  feed_info.feed_contact_email,
+        feed_contact_url:    feed_info.feed_contact_url
       })
     end
     return {


### PR DESCRIPTION
Update to the latest version of our gtfs wrapper:
 - FTP support
 - FeedInfo feed_contact_email, feed_contact_url
 - Agency agency_email

which adds support for fetching via FTP, and support for the agency_email field.

Related to https://github.com/transitland/transitland/issues/204
Related to https://github.com/transitland/transitland/issues/203
Related to https://github.com/transitland/transitland/issues/34