### PR TITLE
removing CodeCov integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ gem 'vcr', group: :test
 gem 'webmock', group: :test
 gem 'airborne', group: :test
 gem 'timecop', group: :test
-gem 'codecov', require: false, group: :test
 gem 'rspec_junit_formatter', '0.2.2', group: :test
 # ^ for CircleCI: https://circleci.com/docs/test-metadata#rspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,10 +110,6 @@ GEM
     c_geohash (1.1.2)
     choice (0.2.0)
     chronic (0.10.2)
-    codecov (0.1.9)
-      json
-      simplecov
-      url
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
     connection_pool (2.2.1)
@@ -379,7 +375,6 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     uniform_notifier (1.10.0)
-    url (0.3.2)
     vcr (3.0.3)
     warden (1.2.7)
       rack (>= 1.0)
@@ -407,7 +402,6 @@ DEPENDENCIES
   byebug
   c_geohash
   carrierwave!
-  codecov
   database_cleaner
   datastore_admin!
   devise

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,5 @@
 require 'simplecov'
 
-if ENV['CIRCLE_ARTIFACTS']
-  # if running on CircleCI, upload coverage report to codecov.io
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
-end
-
 SimpleCov.start do
   load_profile 'rails'
 


### PR DESCRIPTION
it's been noisy rather than useful

related to https://github.com/transitland/transitland-datastore/issues/676