### PR TITLE
stops endpoint: when a stop has a parent, include its Onestop ID

### DIFF
--- a/app/serializers/stop_serializer.rb
+++ b/app/serializers/stop_serializer.rb
@@ -40,23 +40,14 @@ class StopSerializer < CurrentEntitySerializer
              :timezone,
              :osm_way_id,
              :served_by_vehicle_types,
+             :parent_stop_onestop_id,
              :wheelchair_boarding,
              :created_at,
              :updated_at
 
   has_many :operators_serving_stop
   has_many :routes_serving_stop
-end
 
-class StopPlatformSerializer < StopSerializer
-  attributes :parent_stop_onestop_id
-  def parent_stop_onestop_id
-    object.parent_stop.try(:onestop_id)
-  end
-end
-
-class StopEgressSerializer < StopSerializer
-  attributes :parent_stop_onestop_id
   def parent_stop_onestop_id
     object.parent_stop.try(:onestop_id)
   end


### PR DESCRIPTION
closes #971 

adds a `parent_stop_onestop_id` field to the stops endpoint. For example:

```json
{
  "identifiers": [],
  "imported_from_feeds": [{
    "feed_onestop_id": "f-dr5r-nyctsubway",
    "feed_version_sha1": "3b91958379ad4409ec5629f37565252593852869",
    "gtfs_id": "101S"
  }],
  "created_or_updated_in_changeset_id": 12,
  "onestop_id": "s-dr72w7stnh-vancortlandtpark~242st<101s",
  "geometry": {
    "type": "Point",
    "coordinates": [-73.898583,
      40.889248
    ]
  },
  "name": "Van Cortlandt Park - 242 St",
  "tags": {
    "osm_way_id": "141106385"
  },
  "timezone": "America/New_York",
  "osm_way_id": 141106385,
  "served_by_vehicle_types": [
    "metro"
  ],
  "parent_stop_onestop_id": "s-dr72w7stnh-vancortlandtpark~242st",
  "wheelchair_boarding": null,
  "created_at": "2017-02-16T19:43:44.817Z",
  "updated_at": "2017-02-16T20:03:40.796Z",
  "operators_serving_stop": [{
    "operator_name": "MTA New York City Transit",
    "operator_onestop_id": "o-dr5r-nyct"
  }],
  "routes_serving_stop": [{
    "operator_name": "MTA New York City Transit",
    "operator_onestop_id": "o-dr5r-nyct",
    "route_name": "1",
    "route_onestop_id": "r-dr72-1"
  }]
},
```

We don't want to make too many modifications to the `/stops` endpoint, but this seems like a simple addition to allow easier identification of stop relationships, as suggested in #971 