### PR TITLE
Optimize memory before after stops

### DIFF
--- a/app/models/route_stop_pattern.rb
+++ b/app/models/route_stop_pattern.rb
@@ -32,7 +32,7 @@
 class BaseRouteStopPattern < ActiveRecord::Base
   self.abstract_class = true
 
-  attr_accessor :traversed_by, :first_stop_before_geom, :last_stop_after_geom
+  attr_accessor :traversed_by
 end
 
 class RouteStopPattern < BaseRouteStopPattern
@@ -189,21 +189,22 @@ class RouteStopPattern < BaseRouteStopPattern
     a = 0
     b = 0
     c = 0
+    last_stop_after_geom = route.after?(stops[-1][:geometry]) || outlier_stop(stops[-1][:geometry])
     stops.each_index do |i|
       stop_spherical = stops[i]
       this_stop = cartesian_cast(stop_spherical[:geometry])
-      if i == 0 && self.first_stop_before_geom
+      if i == 0 && (route.before?(stops[i][:geometry]) || outlier_stop(this_stop))
         self.stop_distances << 0.0
         next
       elsif i == stops.size - 1
-        if self.last_stop_after_geom
+        if last_stop_after_geom
           self.stop_distances << self[:geometry].length
           break
         else
           c = num_segments - 1
         end
       else
-        if (i + 1 == stops.size - 1) && self.last_stop_after_geom
+        if (i + 1 == stops.size - 1) && last_stop_after_geom
           c = num_segments - 1
         else
           next_stop_spherical = stops[i+1]
@@ -272,16 +273,6 @@ class RouteStopPattern < BaseRouteStopPattern
     issues = []
     if trip.shape_id.nil? || self.geometry.nil? || self.geometry[:coordinates].empty?
       issues << :empty
-    else
-      cartesian_line = cartesian_cast(self[:geometry])
-      first_stop = RouteStopPattern::GEOFACTORY.point(stop_points[0][0],stop_points[0][1])
-      if cartesian_line.before?(first_stop) || outlier_stop(first_stop)
-        issues << :has_before_stop
-      end
-      last_stop = RouteStopPattern::GEOFACTORY.point(stop_points[-1][0],stop_points[-1][1])
-      if cartesian_line.after?(last_stop) || outlier_stop(last_stop)
-        issues << :has_after_stop
-      end
     end
     # more evaluations can go here
     return (issues.size > 0), issues
@@ -289,16 +280,12 @@ class RouteStopPattern < BaseRouteStopPattern
 
   def tl_geometry(stop_points, issues)
     # modify rsp geometry based on issues array from evaluate_geometry
-    self.first_stop_before_geom = false
-    self.last_stop_after_geom = false
     if issues.include?(:empty)
       # create a new geometry from the trip stop points
       self.geometry = RouteStopPattern.line_string(RouteStopPattern.set_precision(stop_points))
       self.is_generated = true
       self.is_modified = true
     end
-    self.first_stop_before_geom = true if issues.include?(:has_before_stop)
-    self.last_stop_after_geom = true if issues.include?(:has_after_stop)
     # more geometry modification can go here
   end
 

--- a/spec/initializers/rgeo_spec.rb
+++ b/spec/initializers/rgeo_spec.rb
@@ -1,9 +1,21 @@
 describe RGeo::Cartesian do
   context 'with additional LineStringMethods' do
-    before(:each) do
-      @factory = RGeo::Cartesian::Factory.new
-      line_points = [[-121.0, 36.0],[-121.0, 34.0],[-122.0, 33.0]]
-      @line = @factory.line_string(line_points.map {|p| @factory.point(p[0],p[1])})
+    context 'before?' do
+      before(:each) do
+        @factory = RGeo::Cartesian::Factory.new
+        @line_points = [[-122.401811, 37.706675],[-122.394935, 37.776348]]
+        @line = @factory.line_string(@line_points.map {|p| @factory.point(p[0],p[1])})
+      end
+
+      it 'checks after?' do
+        point = @factory.point(-122.38, 37.8)
+        expect(@line.after?(point)).to be true
+      end
+
+      it 'checks before?' do
+        point = @factory.point(-122.405, 37.63)
+        expect(@line.before?(point)).to be true
+      end
     end
   end
 

--- a/spec/initializers/rgeo_spec.rb
+++ b/spec/initializers/rgeo_spec.rb
@@ -7,14 +7,24 @@ describe RGeo::Cartesian do
         @line = @factory.line_string(@line_points.map {|p| @factory.point(p[0],p[1])})
       end
 
-      it 'checks after?' do
+      it 'checks after? true' do
         point = @factory.point(-122.38, 37.8)
         expect(@line.after?(point)).to be true
       end
 
-      it 'checks before?' do
+      it 'checks after? false' do
+        point = @factory.point(-122.3975, 37.73)
+        expect(@line.after?(point)).to be false
+      end
+
+      it 'checks before? true' do
         point = @factory.point(-122.405, 37.63)
         expect(@line.before?(point)).to be true
+      end
+
+      it 'checks before? false' do
+        point = @factory.point(-122.3975, 37.73)
+        expect(@line.before?(point)).to be false
       end
     end
   end

--- a/spec/models/route_stop_pattern_spec.rb
+++ b/spec/models/route_stop_pattern_spec.rb
@@ -426,6 +426,17 @@ describe RouteStopPattern do
       expect(distances[1..-1].each_with_index.map { |v, i| v > distances[i] }.all?).to be true
     end
 
+    it 'accurately calculates distances if the last stop is an after? stop' do
+      geom = RouteStopPattern.line_string([[-122.41, 37.65],[-122.401811, 37.706675],[-122.394935, 37.776348]])
+      @rsp.geometry = geom
+      stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.41, 37.65))
+      stop_b.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.401811, 37.706675))
+      stop_c.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.38, 37.78))
+      expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
+                                                              a_value_within(0.1).of(6350.2),
+                                                              a_value_within(0.1).of(14129.7)])
+    end
+
     it 'accurately calculates distances if the last stop is close to the line and is not an after? stop' do
       geom = RouteStopPattern.line_string([[-122.41, 37.65],[-122.401811, 37.706675],[-122.394935, 37.776348]])
       @rsp.geometry = geom
@@ -447,6 +458,17 @@ describe RouteStopPattern do
       expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
                                                               a_value_within(0.1).of(6350.2),
                                                               a_value_within(0.1).of(14129.7)])
+    end
+
+    it 'accurately calculates distances if the first stop is a before? stop' do
+      geom = RouteStopPattern.line_string([[-122.401811, 37.706675],[-122.394935, 37.776348],[-122.39, 37.84]])
+      @rsp.geometry = geom
+      stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.41, 37.69))
+      stop_b.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.394935, 37.776348))
+      stop_c.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.39, 37.84))
+      expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
+                                                              a_value_within(0.1).of(7779.5),
+                                                              a_value_within(0.1).of(14878.5)])
     end
 
     it 'accurately calculates distances if the first stop is close to the line and not a before? stop' do

--- a/spec/models/route_stop_pattern_spec.rb
+++ b/spec/models/route_stop_pattern_spec.rb
@@ -426,7 +426,7 @@ describe RouteStopPattern do
       expect(distances[1..-1].each_with_index.map { |v, i| v > distances[i] }.all?).to be true
     end
 
-    it 'accurately calculates distances if the last stop is close to the line and below the last stop perpendicular' do
+    it 'accurately calculates distances if the last stop is close to the line and is not an after? stop' do
       geom = RouteStopPattern.line_string([[-122.41, 37.65],[-122.401811, 37.706675],[-122.394935, 37.776348]])
       @rsp.geometry = geom
       stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.41, 37.65))
@@ -437,7 +437,7 @@ describe RouteStopPattern do
                                                               a_value_within(0.1).of(10192.9)])
     end
 
-    it 'accurately calculates distances if the last stop is below the last stop perpendicular but not close enough to the line' do
+    it 'accurately calculates distances if the last stop is not an after? stop, but not close enough to the line' do
       # last stop distance should be the length of the line, ~ 14129.7
       geom = RouteStopPattern.line_string([[-122.41, 37.65],[-122.401811, 37.706675],[-122.394935, 37.776348]])
       @rsp.geometry = geom
@@ -449,7 +449,7 @@ describe RouteStopPattern do
                                                               a_value_within(0.1).of(14129.7)])
     end
 
-    it 'accurately calculates distances if the first stop is close to the line and above the first stop perpendicular' do
+    it 'accurately calculates distances if the first stop is close to the line and not a before? stop' do
       geom = RouteStopPattern.line_string([[-122.401811, 37.706675],[-122.394935, 37.776348],[-122.39, 37.84]])
       @rsp.geometry = geom
       stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.40182, 37.7067))
@@ -460,7 +460,7 @@ describe RouteStopPattern do
                                                               a_value_within(0.1).of(14878.5)])
     end
 
-    it 'accurately calculates distances if the first stop is above the first stop perpendicular but not close enough to the line' do
+    it 'accurately calculates distances if the first stop is not a before? stop, but not close enough to the line' do
       # consequently the first stop distance should be 0.0
       geom = RouteStopPattern.line_string([[-122.401811, 37.706675],[-122.394935, 37.776348],[-122.39, 37.84]])
       @rsp.geometry = geom

--- a/spec/models/route_stop_pattern_spec.rb
+++ b/spec/models/route_stop_pattern_spec.rb
@@ -425,6 +425,52 @@ describe RouteStopPattern do
       # expect all distances to be increasing
       expect(distances[1..-1].each_with_index.map { |v, i| v > distances[i] }.all?).to be true
     end
+
+    it 'accurately calculates distances if the last stop is close to the line and below the last stop perpendicular' do
+      geom = RouteStopPattern.line_string([[-122.41, 37.65],[-122.401811, 37.706675],[-122.394935, 37.776348]])
+      @rsp.geometry = geom
+      stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.41, 37.65))
+      stop_b.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.401811, 37.706675))
+      stop_c.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.3975, 37.741))
+      expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
+                                                              a_value_within(0.1).of(6350.2),
+                                                              a_value_within(0.1).of(10192.9)])
+    end
+
+    it 'accurately calculates distances if the last stop is below the last stop perpendicular but not close enough to the line' do
+      # last stop distance should be the length of the line, ~ 14129.7
+      geom = RouteStopPattern.line_string([[-122.41, 37.65],[-122.401811, 37.706675],[-122.394935, 37.776348]])
+      @rsp.geometry = geom
+      stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.41, 37.65))
+      stop_b.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.401811, 37.706675))
+      stop_c.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.39, 37.77))
+      expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
+                                                              a_value_within(0.1).of(6350.2),
+                                                              a_value_within(0.1).of(14129.7)])
+    end
+
+    it 'accurately calculates distances if the first stop is close to the line and above the first stop perpendicular' do
+      geom = RouteStopPattern.line_string([[-122.401811, 37.706675],[-122.394935, 37.776348],[-122.39, 37.84]])
+      @rsp.geometry = geom
+      stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.40182, 37.7067))
+      stop_b.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.394935, 37.776348))
+      stop_c.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.39, 37.84))
+      expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(2.7),
+                                                              a_value_within(0.1).of(7779.5),
+                                                              a_value_within(0.1).of(14878.5)])
+    end
+
+    it 'accurately calculates distances if the first stop is above the first stop perpendicular but not close enough to the line' do
+      # consequently the first stop distance should be 0.0
+      geom = RouteStopPattern.line_string([[-122.401811, 37.706675],[-122.394935, 37.776348],[-122.39, 37.84]])
+      @rsp.geometry = geom
+      stop_a.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.40182, 37.72))
+      stop_b.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.394935, 37.776348))
+      stop_c.update_column(:geometry, RouteStopPattern::GEOFACTORY.point(-122.39, 37.84))
+      expect(@rsp.calculate_distances).to match_array([a_value_within(0.1).of(0.0),
+                                                              a_value_within(0.1).of(7779.5),
+                                                              a_value_within(0.1).of(14878.5)])
+    end
   end
 
   context 'determining outlier stops' do
@@ -446,60 +492,6 @@ describe RouteStopPattern do
       )
       @rsp.stop_pattern = [@sp[0],test_stop.onestop_id,@sp[1]]
       expect(@rsp.outlier_stop(test_stop[:geometry])).to be true
-    end
-  end
-
-  context 'before and after stops' do
-    before(:each) do
-      @trip = GTFS::Trip.new(trip_id: 'test')
-    end
-
-    it 'is marked correctly as having an after stop after evaluation' do
-      stop_points = @geom_points << [-122.38, 37.8]
-      @trip.shape_id = 'test_shape'
-      has_issues, issues = @rsp.evaluate_geometry(@trip, stop_points)
-      expect(has_issues).to be true
-      expect(issues).to match_array([:has_after_stop])
-    end
-
-    it 'does not have an after stop if the last stop is close to the line and below the last stop perpendicular' do
-      stop_points = @geom_points << [-122.3975, 37.741]
-      @trip.shape_id = 'test_shape'
-      has_issues, issues = @rsp.evaluate_geometry(@trip, stop_points)
-      expect(has_issues).to be false
-      expect(issues).to match_array([])
-    end
-
-    it 'has an after stop if the last stop is below the last stop perpendicular but not close enough to the line' do
-      stop_points = @geom_points << [-122.39, 37.77]
-      @trip.shape_id = 'test_shape'
-      has_issues, issues = @rsp.evaluate_geometry(@trip, stop_points)
-      expect(has_issues).to be true
-      expect(issues).to match_array([:has_after_stop])
-    end
-
-    it 'is marked correctly as having a before stop after evaluation' do
-      stop_points = @geom_points.unshift([-122.405, 37.63])
-      @trip.shape_id = 'test_shape'
-      has_issues, issues = @rsp.evaluate_geometry(@trip, stop_points)
-      expect(has_issues).to be true
-      expect(issues).to match_array([:has_before_stop])
-    end
-
-    it 'does not have a before stop if the first stop is close to the line and above the first stop perpendicular' do
-      stop_points = @geom_points.unshift([-122.40182, 37.7067])
-      @trip.shape_id = 'test_shape'
-      has_issues, issues = @rsp.evaluate_geometry(@trip, stop_points)
-      expect(has_issues).to be false
-      expect(issues).to match_array([])
-    end
-
-    it 'has a before stop if the first stop is above the first stop perpendicular but not close enough to the line' do
-      stop_points = @geom_points.unshift([-122.40182, 37.72])
-      @trip.shape_id = 'test_shape'
-      has_issues, issues = @rsp.evaluate_geometry(@trip, stop_points)
-      expect(has_issues).to be true
-      expect(issues).to match_array([:has_before_stop])
     end
   end
 


### PR DESCRIPTION
Moving "before?" and "after?" stop checks into distance calculation itself.