### PR TITLE
SSPs: date=today

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'rgeo-geojson'
 gem 'c_geohash', require: 'geohash'
 gem 'json-schema', '2.5.2' # running into problems with 2.6.0
 gem 'email_validator'
+gem 'tzinfo'
 
 # text matching
 gem 'text'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,6 +447,7 @@ DEPENDENCIES
   squeel
   text
   timecop
+  tzinfo
   unicorn
   vcr
   webmock

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -148,7 +148,14 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
 
     # Departing between...
     if params[:origin_departure_between].present?
-      t1, t2 = AllowFiltering.param_as_array(params, :origin_departure_between)
+      r = /^(now)([-+ ]\d+)?$/
+      t1, t2 = AllowFiltering.param_as_array(params, :origin_departure_between).map do |t|
+        if r.match(t)
+          GTFS::WideTime.new(tz_now.seconds_since_midnight + r.match(t)[2].to_i).to_s
+        else
+          GTFS::WideTime.parse(t)
+        end
+      end
       @ssps = @ssps.where_origin_departure_between(t1, t2)
     end
 

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -120,7 +120,14 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
       @ssps = @ssps.where_import_level(AllowFiltering.param_as_array(params, :import_level))
     end
     # Service on a date
-    if params[:date].present?
+    if params[:date].presence == "today"
+      tz_onestop_id = params[:origin_onestop_id].presence || params[:destination_onestop_id].presence || params[:operator_onestop_id].presence
+      fail Exception.new('Must provide an origin_onestop_id, destination_onestop_id, or operator_onestop_id for date=today') unless tz_onestop_id
+      tz_entity = OnestopId.find!(tz_onestop_id)
+      today = TZInfo::Timezone.get(tz_entity.timezone).utc_to_local(Time.now).to_date
+      # puts "TIMEZONE: #{tz_entity.timezone} TODAY: #{today}"
+      @ssps = @ssps.where_service_on_date(today)
+    elsif params[:date].present?
       @ssps = @ssps.where_service_on_date(params[:date])
     end
     if params[:service_from_date].present?

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -110,27 +110,32 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
     if params[:active].presence == 'true'
       @ssps = @ssps.where_imported_from_active_feed_version
     end
+
     # Feed
     feed_onestop_id = params[:feed_onestop_id].presence || params[:imported_from_feed].presence
     if feed_onestop_id
       @ssps = @ssps.where(feed: Feed.find_by_onestop_id!(feed_onestop_id))
     end
+
     # FeedVersion Import level
     if params[:import_level].present?
       @ssps = @ssps.where_import_level(AllowFiltering.param_as_array(params, :import_level))
     end
+
     # Service on a date
     if params[:date].presence == "today"
       @ssps = @ssps.where_service_on_date(tz_now.to_date)
     elsif params[:date].present?
       @ssps = @ssps.where_service_on_date(params[:date])
     end
+
     if params[:service_from_date].present?
       @ssps = @ssps.where_service_from_date(params[:service_from_date])
     end
     if params[:service_before_date].present?
       @ssps = @ssps.where_service_before_date(params[:service_before_date])
     end
+
     # Service between stops
     if params[:origin_onestop_id].present?
       origin_stops = Stop.find_by_onestop_ids!(AllowFiltering.param_as_array(params, :origin_onestop_id))
@@ -140,15 +145,18 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
       destination_stops = Stop.find_by_onestop_ids!(AllowFiltering.param_as_array(params, :destination_onestop_id))
       @ssps = @ssps.where(destination: destination_stops)
     end
+
     # Departing between...
     if params[:origin_departure_between].present?
       t1, t2 = AllowFiltering.param_as_array(params, :origin_departure_between)
       @ssps = @ssps.where_origin_departure_between(t1, t2)
     end
+
     # Service by trip id
     if params[:trip].present?
       @ssps = @ssps.where(trip: params[:trip])
     end
+
     # Service on a route
     if params[:route_onestop_id].present?
       routes = Route.find_by_onestop_ids!(AllowFiltering.param_as_array(params, :route_onestop_id))
@@ -162,6 +170,7 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
       operators = Operator.find_by_onestop_ids!(AllowFiltering.param_as_array(params, :operator_onestop_id))
       @ssps = @ssps.where(operator: operators)
     end
+
     # Stops in a bounding box
     if params[:bbox].present?
       @ssps = @ssps.where_origin_bbox(params[:bbox])

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -121,12 +121,7 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
     end
     # Service on a date
     if params[:date].presence == "today"
-      tz_onestop_id = params[:origin_onestop_id].presence || params[:destination_onestop_id].presence || params[:operator_onestop_id].presence
-      fail Exception.new('Must provide an origin_onestop_id, destination_onestop_id, or operator_onestop_id for date=today') unless tz_onestop_id
-      tz_entity = OnestopId.find!(tz_onestop_id)
-      today = TZInfo::Timezone.get(tz_entity.timezone).utc_to_local(Time.now).to_date
-      # puts "TIMEZONE: #{tz_entity.timezone} TODAY: #{today}"
-      @ssps = @ssps.where_service_on_date(today)
+      @ssps = @ssps.where_service_on_date(tz_now.to_date)
     elsif params[:date].present?
       @ssps = @ssps.where_service_on_date(params[:date])
     end

--- a/app/controllers/api/v1/schedule_stop_pairs_controller.rb
+++ b/app/controllers/api/v1/schedule_stop_pairs_controller.rb
@@ -181,4 +181,14 @@ class Api::V1::ScheduleStopPairsController < Api::V1::BaseApiController
       feed_version
     ]}
   end
+
+  private
+
+  def tz_now
+    tz_onestop_id = params[:origin_onestop_id].presence || params[:destination_onestop_id].presence || params[:operator_onestop_id].presence
+    fail Exception.new('Must provide an origin_onestop_id, destination_onestop_id, or operator_onestop_id to use "now" or "today" relative times') unless tz_onestop_id
+    tz_entity = OnestopId.find!(tz_onestop_id)
+    TZInfo::Timezone.get(tz_entity.timezone).utc_to_local(DateTime.now)
+  end
+
 end

--- a/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
+++ b/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
@@ -50,6 +50,9 @@ describe Api::V1::ScheduleStopPairsController do
     end
 
     context 'date' do
+      it 'accepts date=today' do
+
+      end
     end
 
     context 'service_from_date' do

--- a/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
+++ b/spec/controllers/api/v1/schedule_stop_pairs_controller_spec.rb
@@ -49,9 +49,55 @@ describe Api::V1::ScheduleStopPairsController do
       end
     end
 
-    context 'date' do
-      it 'accepts date=today' do
+    context 'date=today, time=now' do
+      before(:each) {
+        @origin = @ssps[0].origin
+        @origin.update!(timezone: 'America/Los_Angeles')
+        @ssps[0].update(
+          origin: @origin,
+          origin_departure_time: '10:00:00',
+          service_start_date: '1999-01-01',
+          service_end_date: '1999-01-01',
+          service_days_of_week: [false, false, false, false, true, false, false]
+        )
+        @ssps[1].update(
+          origin: @origin,
+          origin_departure_time: '12:00:00',
+          service_start_date: '1999-01-01',
+          service_end_date: '1999-01-01',
+          service_days_of_week: [false, false, false, false, true, false, false]
+        )
+        @ssps[2].update(
+          origin: @origin,
+          origin_departure_time: '14:00:00',
+          service_start_date: '1999-02-01',
+          service_end_date: '1999-02-01',
+          service_days_of_week: [false, false, false, false, true, false, false]
+        )
+        @now = DateTime.parse('1999-01-01T18:00:00+00:00')
+      }
 
+      it 'accepts date=today' do
+        Timecop.freeze(@now) do
+          get :index, origin_onestop_id: @origin.onestop_id, date: 'today'
+          expect_json_sizes(schedule_stop_pairs: 2)
+        end
+      end
+
+      it 'accepts origin_departure_between=now' do
+        Timecop.freeze(@now) do
+          # now is 10am America/Los_Angeles
+          get :index, origin_onestop_id: @origin.onestop_id, origin_departure_between: '11:00:00'
+          expect_json_sizes(schedule_stop_pairs: 2)
+          get :index, origin_onestop_id: @origin.onestop_id, origin_departure_between: 'now-600'
+          expect_json_sizes(schedule_stop_pairs: 3)
+          get :index, origin_onestop_id: @origin.onestop_id, origin_departure_between: 'now+600'
+          expect_json_sizes(schedule_stop_pairs: 2)
+          get :index, origin_onestop_id: @origin.onestop_id, origin_departure_between: '00:00:00,now+600'
+          expect_json_sizes(schedule_stop_pairs: 1)
+          get :index, origin_onestop_id: @origin.onestop_id, origin_departure_between: 'now-600,now+600'
+          expect_json_sizes(schedule_stop_pairs: 1)
+        end
       end
     end
 


### PR DESCRIPTION
Allow `date=today` query for SSPs.

When using `today`, you must specify either an `origin_onestop_id`, `destination_onestop_id`, or `operator_onestop_id`; this will set the correct timezone to get the date in the local time.

Resolves #965
Resolves #1008 