### PR TITLE
FeedValidationWorker

### DIFF
--- a/app/services/feed_fetcher_service.rb
+++ b/app/services/feed_fetcher_service.rb
@@ -119,7 +119,9 @@ class FeedFetcherService
       data = data.merge!(read_gtfs_info(gtfs))
       feed_version.update!(data)
       # Enqueue validators
-      FeedValidationWorker.perform_async(feed_version.sha1)
+      if Figaro.env.run_google_feedvalidator.presence == 'true'
+        FeedValidationWorker.perform_async(feed_version.sha1)
+      end
     end
     # Return the found or created feed_version
     feed_version

--- a/app/services/feed_fetcher_service.rb
+++ b/app/services/feed_fetcher_service.rb
@@ -3,7 +3,6 @@ class FeedFetcherService
 
   REFETCH_WAIT = 24.hours
   SPLIT_REFETCH_INTO_GROUPS = 48 # and only refetch the first group
-  FEEDVALIDATOR_PATH = './virtualenv/bin/feedvalidator.py'
 
   def self.fetch_this_feed_now(feed)
     sync_fetch_and_return_feed_versions([feed])
@@ -77,31 +76,6 @@ class FeedFetcherService
     (url || "").partition("#").last.presence
   end
 
-  def self.run_google_feedvalidator(filename)
-    # Validate
-    return unless Figaro.env.run_google_feedvalidator.presence == 'true'
-    # Create a tempfile to use the filename.
-    outfile = nil
-    Tempfile.open(['feedvalidator', '.html']) do |tmpfile|
-      outfile = tmpfile.path
-    end
-
-    # Run feedvalidator
-    feedvalidator_output = nil
-    IO.popen([FEEDVALIDATOR_PATH, '-n', '-o', outfile, filename], "w+") do |io|
-      io.write("\n")
-      io.close_write
-      feedvalidator_output = io.read
-    end
-    # feedvalidator_output
-
-    return unless File.exists?(outfile)
-    # Unlink temporary file
-    file_feedvalidator = File.open(outfile)
-    File.unlink(outfile)
-    file_feedvalidator
-  end
-
   def self.fetch_and_normalize_feed_version(feed)
     # Fetch GTFS
     gtfs = GTFS::Source.build(
@@ -135,18 +109,17 @@ class FeedFetcherService
     )
     # Is this a new feed_version?
     if feed_version.file.url.nil?
-      # Validate the new data
-      file_feedvalidator = run_google_feedvalidator(gtfs_file.path)
       # Save the file attachments
       data = {
         url: feed.url,
         fetched_at: DateTime.now,
         file: gtfs_file,
         file_raw: gtfs_file_raw,
-        file_feedvalidator: file_feedvalidator,
       }
       data = data.merge!(read_gtfs_info(gtfs))
       feed_version.update!(data)
+      # Enqueue validators
+      FeedValidationWorker.perform_async(feed_version.sha1)
     end
     # Return the found or created feed_version
     feed_version

--- a/app/services/feed_validation_service.rb
+++ b/app/services/feed_validation_service.rb
@@ -30,9 +30,9 @@ class FeedValidationService
 
   def self.run_validators(feed_version)
     # Validate the new data
-    gtfs_filename = file.local_path_copying_locally_if_needed
+    gtfs_filename = feed_version.file.local_path_copying_locally_if_needed
     file_feedvalidator = run_google_feedvalidator(gtfs_filename)
-    file.remove_any_local_cached_copies
+    feed_version.file.remove_any_local_cached_copies
     # Save
     feed_version.update!(
       file_feedvalidator: file_feedvalidator,

--- a/app/services/feed_validation_service.rb
+++ b/app/services/feed_validation_service.rb
@@ -4,8 +4,6 @@ class FeedValidationService
   FEEDVALIDATOR_PATH = './virtualenv/bin/feedvalidator.py'
 
   def self.run_google_feedvalidator(filename)
-    # Validate
-    return unless Figaro.env.run_google_feedvalidator.presence == 'true'
     # Create a tempfile to use the filename.
     outfile = nil
     Tempfile.open(['feedvalidator', '.html']) do |tmpfile|
@@ -29,14 +27,21 @@ class FeedValidationService
   end
 
   def self.run_validators(feed_version)
-    # Validate the new data
+    # Copy file
     gtfs_filename = feed_version.file.local_path_copying_locally_if_needed
+    fail Exception.new('FeedVersion has no file attachment') unless gtfs_filename
+
+    # Run validators
     file_feedvalidator = run_google_feedvalidator(gtfs_filename)
+
+    # Cleanup
     feed_version.file.remove_any_local_cached_copies
+
     # Save
     feed_version.update!(
       file_feedvalidator: file_feedvalidator,
     )
+
     # Return
     feed_version
   end

--- a/app/services/feed_validation_service.rb
+++ b/app/services/feed_validation_service.rb
@@ -1,0 +1,43 @@
+class FeedValidationService
+  include Singleton
+
+  FEEDVALIDATOR_PATH = './virtualenv/bin/feedvalidator.py'
+
+  def self.run_google_feedvalidator(filename)
+    # Validate
+    return unless Figaro.env.run_google_feedvalidator.presence == 'true'
+    # Create a tempfile to use the filename.
+    outfile = nil
+    Tempfile.open(['feedvalidator', '.html']) do |tmpfile|
+      outfile = tmpfile.path
+    end
+
+    # Run feedvalidator
+    feedvalidator_output = nil
+    IO.popen([FEEDVALIDATOR_PATH, '-n', '-o', outfile, filename], "w+") do |io|
+      io.write("\n")
+      io.close_write
+      feedvalidator_output = io.read
+    end
+    # feedvalidator_output
+
+    return unless File.exists?(outfile)
+    # Unlink temporary file
+    file_feedvalidator = File.open(outfile)
+    File.unlink(outfile)
+    file_feedvalidator
+  end
+
+  def self.run_validators(feed_version)
+    # Validate the new data
+    gtfs_filename = file.local_path_copying_locally_if_needed
+    file_feedvalidator = run_google_feedvalidator(gtfs_filename)
+    file.remove_any_local_cached_copies
+    # Save
+    feed_version.update!(
+      file_feedvalidator: file_feedvalidator,
+    )
+    # Return
+    feed_version
+  end
+end

--- a/app/workers/feed_validation_worker.rb
+++ b/app/workers/feed_validation_worker.rb
@@ -1,0 +1,10 @@
+class FeedValidationWorker
+  include Sidekiq::Worker
+
+  sidekiq_options unique: :until_and_while_executing,
+                  unique_job_expiration: 22 * 60 * 60 # 22 hours
+
+  def perform(feed_version_sha1)
+    # do stuff
+  end
+end

--- a/app/workers/feed_validation_worker.rb
+++ b/app/workers/feed_validation_worker.rb
@@ -5,6 +5,7 @@ class FeedValidationWorker
                   unique_job_expiration: 22 * 60 * 60 # 22 hours
 
   def perform(feed_version_sha1)
-    # do stuff
+    feed_version = FeedVersion.find_by!(sha1: feed_version_sha1)
+    FeedValidationService.run_validators(feed_version)
   end
 end

--- a/spec/services/feed_validation_service_spec.rb
+++ b/spec/services/feed_validation_service_spec.rb
@@ -1,4 +1,14 @@
 describe FeedValidationService do
-  context 'run validators' do
+  context 'validators' do
+    before(:each) {
+      allow(FeedValidationService).to receive(:run_google_feedvalidator) { Tempfile.new(['test','.html']) }
+    }
+
+    it '.run_validators' do
+      feed_version = create(:feed_version_example)
+      expect(feed_version.reload.file_feedvalidator.url).to be nil
+      FeedValidationService.run_validators(feed_version)
+      expect(feed_version.reload.file_feedvalidator.url).to end_with('.html')
+    end
   end
 end

--- a/spec/services/feed_validation_service_spec.rb
+++ b/spec/services/feed_validation_service_spec.rb
@@ -1,0 +1,4 @@
+describe FeedValidationService do
+  context 'run validators' do
+  end
+end

--- a/spec/workers/feed_validation_worker_spec.rb
+++ b/spec/workers/feed_validation_worker_spec.rb
@@ -1,4 +1,15 @@
 describe FeedValidationWorker do
-  context 'enqueue FeedValidationWorker' do
+  before(:each) {
+    allow(FeedValidationService).to receive(:run_google_feedvalidator) { Tempfile.new(['test','.html']) }
+  }
+
+  context 'runs FeedValidationService' do
+    it 'attaches output HTML' do
+      feed_version = create(:feed_version_example)
+      Sidekiq::Testing.inline! do
+        FeedValidationWorker.perform_async(feed_version.sha1)
+      end
+      expect(feed_version.reload.file_feedvalidator.url).to end_with('.html')
+    end
   end
 end

--- a/spec/workers/feed_validation_worker_spec.rb
+++ b/spec/workers/feed_validation_worker_spec.rb
@@ -1,0 +1,4 @@
+describe FeedValidationWorker do
+  context 'enqueue FeedValidationWorker' do
+  end
+end


### PR DESCRIPTION
Create a new FeedValidationService and FeedValidatorWorker job.

This moves the validation process out of FeedFetchService and sets up the framework for adding additional validators, statistics generation, etc. in the future.

Related to #888 

Resolves #1009 