### PR TITLE
Feed version info serializer updates

### DIFF
--- a/app/controllers/api/v1/feed_version_infos_controller.rb
+++ b/app/controllers/api/v1/feed_version_infos_controller.rb
@@ -35,6 +35,13 @@ class Api::V1::FeedVersionInfosController < Api::V1::BaseApiController
     end
   end
 
+  def paginated_json_collection(collection)
+    result = super
+    result[:root] = :feed_version_infos
+    result[:each_serializer] = FeedVersionInfoSerializer
+    result
+  end
+
   private
 
   def set_feed_version_info

--- a/app/models/feed_version_info.rb
+++ b/app/models/feed_version_info.rb
@@ -17,7 +17,7 @@
 
 class FeedVersionInfo < ActiveRecord::Base
   belongs_to :feed_version
-  validates :feed_version_id, uniqueness: { scope: :type }
+  validates :feed_version_id, uniqueness: { scope: :type }, presence: true
 end
 
 class FeedVersionInfoStatistics < FeedVersionInfo

--- a/app/serializers/feed_version_info_serializer.rb
+++ b/app/serializers/feed_version_info_serializer.rb
@@ -17,6 +17,7 @@
 
 class FeedVersionInfoSerializer < ApplicationSerializer
   attributes :id,
+             :type,
              :data,
              :feed_version_sha1,
              :created_at,


### PR DESCRIPTION
Set root node, override default serializer, avoid falling back to default serializer.

Also, require FeedVersion association.