### PR TITLE
StopPlatform: mark as generated

### DIFF
--- a/app/serializers/stop_station_serializer.rb
+++ b/app/serializers/stop_station_serializer.rb
@@ -8,6 +8,7 @@ class StopStationSerializer < CurrentEntitySerializer
                :served_by_vehicle_types,
                :timezone,
                :wheelchair_boarding,
+               :generated,
                :created_at,
                :updated_at,
                :last_conflated_at
@@ -17,6 +18,10 @@ class StopStationSerializer < CurrentEntitySerializer
 
      def issues
        issues = object.issues
+     end
+
+     def generated
+       !object.persisted?
      end
   end
   # Egress serializer
@@ -28,12 +33,17 @@ class StopStationSerializer < CurrentEntitySerializer
                :timezone,
                :osm_way_id,
                :wheelchair_boarding,
+               :generated,
                :created_at,
                :updated_at
                :last_conflated_at
 
      def issues
        issues = object.issues
+     end
+
+     def generated
+       !object.persisted?
      end
   end
 
@@ -45,7 +55,7 @@ class StopStationSerializer < CurrentEntitySerializer
       name: object.name,
       timezone: object.timezone,
       last_conflated_at: object.last_conflated_at,
-      osm_way_id: object.osm_way_id
+      osm_way_id: object.osm_way_id,
     )]
   end
 
@@ -57,7 +67,7 @@ class StopStationSerializer < CurrentEntitySerializer
       timezone: object.timezone,
       operators_serving_stop: object.operators_serving_stop,
       routes_serving_stop: object.routes_serving_stop,
-      tags: {}
+      tags: {},
     )]
   end
 

--- a/spec/controllers/api/v1/stop_stations_controller_spec.rb
+++ b/spec/controllers/api/v1/stop_stations_controller_spec.rb
@@ -1,4 +1,15 @@
 describe Api::V1::StopStationsController do
+  describe 'GET show' do
+    context 'generated' do
+      it 'returns generated stop platform' do
+        stop_platform = create(:stop_platform)
+        get :show, id: stop_platform.parent_stop.onestop_id
+        expect_json({ stop_platforms: -> (i) { expect(i.first[:generated]).to be_falsey } })
+        expect_json({ stop_egresses: -> (i) { expect(i.first[:generated]).to be_truthy } })
+      end
+    end
+  end
+
   describe 'GET index' do
     context 'as JSON' do
       context 'with issues' do


### PR DESCRIPTION
When a StopPlatform or StopEgress is generated by the serializer, and does not actually exist as a real entity, mark this in the serializer with a `generated` attribute.

See: #1066 