### PR TITLE
Issue from_feed query optimization

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -19,12 +19,10 @@ class Issue < ActiveRecord::Base
 
   scope :with_type, -> (search_string) { where(issue_type: search_string.split(',')) }
   scope :from_feed, -> (feed_onestop_id) {
-    where("issues.id IN (SELECT entities_with_issues.issue_id FROM entities_with_issues INNER JOIN
-    entities_imported_from_feed ON entities_with_issues.entity_id=entities_imported_from_feed.entity_id
-    AND entities_with_issues.entity_type=entities_imported_from_feed.entity_type WHERE entities_imported_from_feed.feed_id=?)
-    OR issues.id in (SELECT issues.id FROM issues INNER JOIN changesets ON
-    issues.created_by_changeset_id=changesets.id WHERE changesets.feed_id=?)",
-    Feed.find_by_onestop_id!(feed_onestop_id), Feed.find_by_onestop_id!(feed_onestop_id))
+    joins("INNER JOIN entities_with_issues ON entities_with_issues.issue_id = issues.id")
+      .joins("INNER JOIN entities_imported_from_feed ON entities_imported_from_feed.entity_id = entities_with_issues.entity_id AND entities_imported_from_feed.entity_type = entities_with_issues.entity_type")
+      .where("entities_imported_from_feed.feed_id = ?", Feed.find_by_onestop_id!(feed_onestop_id).id)
+      .distinct
   }
 
   CATEGORIES = {

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -57,18 +57,6 @@ describe Issue do
     expect(Issue.from_feed('f-9q9-bart').size).to eq 1
   end
 
-  it '.from_feed having no entities_with_issues' do
-    feed1 = create(:feed_sfmta)
-    feed2 = create(:feed_bart)
-    changeset1 = create(:changeset, imported_from_feed: feed1)
-    changeset2 = create(:changeset, imported_from_feed: feed2)
-    Issue.new(created_by_changeset: changeset1, issue_type: 'stop_position_inaccurate').save!
-    Issue.new(created_by_changeset: changeset1, issue_type: 'rsp_line_only_stop_points').save!
-    Issue.new(created_by_changeset: changeset2, issue_type: 'rsp_line_only_stop_points').save!
-    expect(Issue.from_feed('f-9q8y-sfmta').size).to eq 2
-    expect(Issue.from_feed('f-9q9-bart').size).to eq 1
-  end
-
   context 'existing issues' do
     before(:each) do
       @changeset1 = create(:changeset)


### PR DESCRIPTION
Resolves #1116

Note:

This scope no longer also joins on "changeset.imported_from_feed = issue.created_by_changeset_id" 

This relied on overloading the intended purpose of `changeset.imported_from_feed`, and it is difficult to write a single `from_feed` query with good performance for this use-case.