### PR TITLE
Send change_payload created_at and update_at in API response.

### DIFF
--- a/app/serializers/change_payload_serializer.rb
+++ b/app/serializers/change_payload_serializer.rb
@@ -14,5 +14,9 @@
 #
 
 class ChangePayloadSerializer < ApplicationSerializer
-  attributes :id, :changeset_id, :payload
+  attributes :id,
+             :created_at,
+             :updated_at,
+             :changeset_id,
+             :payload
 end


### PR DESCRIPTION
Dispatcher expects the create and update dates to be sent in the response but they were missing.